### PR TITLE
Change PSD assignment logic

### DIFF
--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -78,15 +78,8 @@ def get_psd(input_tuple):
     delta_f = strain_segments.delta_f
 
     logging.info('%d: calculating psd', i)
-    # Estimate the PSD for each analysis segment from the same data pycbc_inspiral
-    # would use for it (a stretch centred on the segment), so downstream products
-    # (sensitivity plots, injection optimal SNR, ...) match the search.
-    analysis_segments = [
-        (seg.start, seg.stop, seg.start + ana.start, seg.start + ana.stop)
-        for seg, ana in zip(strain_segments.segment_slices,
-                            strain_segments.analyze_slices)]
     psds_and_times = pycbc.psd.generate_segment_psds(args, gwstrain,
-                      analysis_segments, flen, delta_f, flow,
+                      strain_segments.psd_segments(), flen, delta_f, flow,
                       dyn_range_factor=pycbc.DYN_RANGE_FAC)
 
     lpsd = []

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -75,15 +75,26 @@ def get_psd(input_tuple):
 
     flow = args.low_frequency_cutoff
     flen = strain_segments.freq_len
-    tlen = strain_segments.time_len
     delta_f = strain_segments.delta_f
 
     logging.info('%d: calculating psd', i)
-    psds_and_times = pycbc.psd.generate_overlapping_psds(args, gwstrain,
-                      flen, delta_f, flow, dyn_range_factor=pycbc.DYN_RANGE_FAC)
+    # Estimate the PSD for each analysis segment from the same data pycbc_inspiral
+    # would use for it (a stretch centred on the segment), so downstream products
+    # (sensitivity plots, injection optimal SNR, ...) match the search.
+    analysis_segments = [
+        (seg.start, seg.stop, seg.start + ana.start, seg.start + ana.stop)
+        for seg, ana in zip(strain_segments.segment_slices,
+                            strain_segments.analyze_slices)]
+    psds_and_times = pycbc.psd.generate_segment_psds(args, gwstrain,
+                      analysis_segments, flen, delta_f, flow,
+                      dyn_range_factor=pycbc.DYN_RANGE_FAC)
 
     lpsd = []
+    seen = set()
     for start_idx, end_idx, psd in psds_and_times:
+        if (start_idx, end_idx) in seen:
+            continue
+        seen.add((start_idx, end_idx))
         start_time = gwstrain.start_time + start_idx/gwstrain.sample_rate
         end_time = gwstrain.start_time + end_idx/gwstrain.sample_rate
         lpsd.append((psd.numpy(), psd.delta_f, int(start_time), int(end_time)))

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -14,7 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import copy
-import igwn_segments as segments
+import logging
 from pycbc.psd.read import *
 from pycbc.psd.analytical import *
 from pycbc.psd.analytical_space import *
@@ -473,20 +473,46 @@ def verify_psd_options_multi_ifo(opt, parser, ifos):
                       ['--psd-segment-stride', '--psd-segment-length'],
                           required_by = "--psd-estimation")
 
-def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
-                              dyn_range_factor=1., precision=None):
-    """Generate a set of overlapping PSDs to cover a stretch of data. This
-    allows one to analyse a long stretch of data with PSD measurements that
-    change with time.
+def psd_estimation_data_length(opt, sample_rate, input_data_len):
+    """Number of samples of data used for one ``--psd-estimation`` PSD estimate,
+    i.e. ``(psd_num_segments - 1) * psd_segment_stride + psd_segment_length``
+    (matching the convention used by ``from_cli`` / ``welch``)."""
+    seg_stride = int(opt.psd_segment_stride * sample_rate)
+    seg_len = int(opt.psd_segment_length * sample_rate)
+    if opt.psd_num_segments is None:
+        num_segments = int(input_data_len // seg_stride) - 1
+    else:
+        num_segments = int(opt.psd_num_segments)
+    return (num_segments - 1) * seg_stride + seg_len
+
+
+def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
+                          dyn_range_factor=1., precision=None):
+    """Estimate a PSD for each analysis segment.
+
+    For ``--psd-estimation`` the PSD for a segment is measured from a stretch of
+    ``gwstrain`` centred on that segment and slid wholly inside the available
+    data, so that the data being analysed is always part of the data used to
+    estimate its own PSD. This avoids a spurious, position-dependent inflation
+    of the matched-filter SNR on the part of a segment that a PSD estimate did
+    not see (see https://github.com/gwastro/pycbc/issues/5280). Segments that
+    resolve to the same data window share a PSD object, and a warning is logged
+    for any segment whose analysed span the available data cannot fully cover.
+
+    For a static PSD (``--psd-model`` / ``--psd-file`` / ``--asd-file``) the one
+    PSD is returned for every segment.
 
     Parameters
     -----------
     opt : object
-        Result of parsing the CLI with OptionParser, or any object with the
-        required attributes (psd_model, psd_file, asd_file, psd_estimation,
-        psd_segment_length, psd_segment_stride, psd_inverse_length, psd_output).
-    gwstrain : Strain object
-        The timeseries of raw data on which to estimate PSDs.
+        Result of parsing the CLI, or any object with the attributes needed by
+        ``from_cli`` (single-ifo).
+    gwstrain : TimeSeries
+        The timeseries of data on which to estimate PSDs.
+    analysis_segments : list of (seg_start, seg_stop, ana_start, ana_stop)
+        Sample indices into ``gwstrain``: ``seg_start``/``seg_stop`` bound the
+        analysis segment; ``ana_start``/``ana_stop`` bound the portion analysed
+        for triggers and are used only to decide whether to warn about coverage.
     flen : int
         The length in samples of the output PSDs.
     delta_f : float
@@ -494,77 +520,84 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
     flow: float
         The low frequency cutoff to use when calculating the PSD, in hertz.
     dyn_range_factor : {1, float}
-        For PSDs taken from models or text files, if `dyn_range_factor` is
-        not None, then the PSD is multiplied by `dyn_range_factor` ** 2.
+        For PSDs taken from models or text files, the PSD is multiplied by
+        ``dyn_range_factor ** 2``.
     precision : str, choices (None,'single','double')
-        If not specified, or specified as None, the precision of the returned
-        PSD will match the precision of the data, if measuring a PSD, or will
-        match the default precision of the model if using an analytical PSD.
-        If 'single' the PSD will be converted to float32, if not already in
-        that precision. If 'double' the PSD will be converted to float64, if
-        not already in that precision.
+        Precision of the returned PSDs (see ``from_cli``).
 
     Returns
     --------
-    psd_and_times : list of (start, end, PSD) tuples
-        This is a list of tuples containing one entry for each PSD. The first
-        and second entries (start, end) in each tuple represent the index
-        range of the gwstrain data that was used to estimate that PSD. The
-        third entry (psd) contains the PSD estimate between that interval.
+    psds_and_times : list of (start, end, PSD) tuples
+        One entry per input segment, in the same order. ``start`` and ``end``
+        are the ``gwstrain`` sample range used to estimate that segment's PSD;
+        ``PSD`` objects are shared between segments with the same window.
     """
     if not opt.psd_estimation:
         psd = from_cli(opt, flen, delta_f, flow, strain=gwstrain,
                        dyn_range_factor=dyn_range_factor, precision=precision)
-        psds_and_times = [ (0, len(gwstrain), psd) ]
-        return psds_and_times
+        return [(0, len(gwstrain), psd) for _ in analysis_segments]
 
-    # Figure out the data length used for PSD generation
-    seg_stride = int(opt.psd_segment_stride * gwstrain.sample_rate)
-    seg_len = int(opt.psd_segment_length * gwstrain.sample_rate)
+    sample_rate = gwstrain.sample_rate
     input_data_len = len(gwstrain)
+    psd_data_len = psd_estimation_data_length(opt, sample_rate, input_data_len)
 
-    if opt.psd_num_segments is None:
-        # FIXME: Should we make --psd-num-segments mandatory?
-        #        err_msg = "You must supply --num-segments."
-        #        raise ValueError(err_msg)
-        num_segments = int(input_data_len // seg_stride) - 1
-    else:
-        num_segments = int(opt.psd_num_segments)
-
-    psd_data_len = (num_segments - 1) * seg_stride + seg_len
-
-    # How many unique PSD measurements is this?
-    psds_and_times = []
     if input_data_len < psd_data_len:
-        err_msg = "Input data length must be longer than data length needed "
-        err_msg += "to estimate a PSD. You specified that a PSD should be "
-        err_msg += "estimated with %d seconds. " %(psd_data_len)
-        err_msg += "Input data length is %d seconds. " %(input_data_len)
-        raise ValueError(err_msg)
-    elif input_data_len == psd_data_len:
-        num_psd_measurements = 1
-        psd_stride = 0
-    else:
-        num_psd_measurements = int(2 * (input_data_len-1) / psd_data_len)
-        psd_stride = int((input_data_len - psd_data_len) / num_psd_measurements)
+        raise ValueError(
+            "Input data (%.0fs) is shorter than the data needed to estimate a "
+            "PSD ((psd-num-segments - 1) * psd-segment-stride + "
+            "psd-segment-length = %.0fs)."
+            % (input_data_len / sample_rate, psd_data_len / sample_rate))
 
-    for idx in range(num_psd_measurements):
-        if idx == (num_psd_measurements - 1):
-            start_idx = input_data_len - psd_data_len
-            end_idx = input_data_len
-        else:
-            start_idx = psd_stride * idx
-            end_idx = psd_data_len + psd_stride * idx
-        strain_part = gwstrain[start_idx:end_idx]
-        psd = from_cli(opt, flen, delta_f, flow, strain=strain_part,
-                       dyn_range_factor=dyn_range_factor, precision=precision)
-        psds_and_times.append( (start_idx, end_idx, psd) )
+    cache = {}
+    psds_and_times = []
+    uncovered = []
+    for seg_start, seg_stop, ana_start, ana_stop in analysis_segments:
+        # Centre the PSD-estimation stretch on the analysis segment, then slide
+        # it wholly inside the available data.
+        centre = (seg_start + seg_stop) // 2
+        psd_start = min(max(centre - psd_data_len // 2, 0),
+                        input_data_len - psd_data_len)
+        psd_stop = psd_start + psd_data_len
+
+        if psd_start > ana_start or psd_stop < ana_stop:
+            uncovered.append((ana_start, ana_stop, psd_start, psd_stop))
+
+        if (psd_start, psd_stop) not in cache:
+            cache[(psd_start, psd_stop)] = from_cli(
+                opt, flen, delta_f, flow, strain=gwstrain[psd_start:psd_stop],
+                dyn_range_factor=dyn_range_factor, precision=precision)
+        psds_and_times.append((psd_start, psd_stop, cache[(psd_start, psd_stop)]))
+
+    if uncovered:
+        epoch = float(gwstrain.start_time)
+        a0, a1, p0, p1 = uncovered[0]
+        logging.warning(
+            "%d of %d analysis segment(s) are not fully covered by the data "
+            "used to estimate their PSD, so the matched-filter SNR near the "
+            "uncovered edge(s) will be slightly over-estimated. Increase "
+            "--psd-num-segments (or analyse more data) so that "
+            "(psd-num-segments - 1) * psd-segment-stride + psd-segment-length "
+            ">= the analysis segment length. First affected segment: analysed "
+            "[%.1f, %.1f] but PSD estimated from [%.1f, %.1f].",
+            len(uncovered), len(analysis_segments),
+            epoch + a0 / sample_rate, epoch + a1 / sample_rate,
+            epoch + p0 / sample_rate, epoch + p1 / sample_rate)
+
     return psds_and_times
 
 def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
                                dyn_range_factor=1., precision=None):
-    """Generate a set of overlapping PSDs covering the data in GWstrain.
-    Then associate these PSDs with the appropriate segment in strain_segments.
+    """Measure a PSD for every analysis segment and store it on the segment.
+
+    With ``--psd-model``, ``--psd-file`` or ``--asd-file`` a single PSD is used
+    for every segment. With ``--psd-estimation`` the PSD for each analysis
+    segment is measured from a stretch of ``gwstrain`` centred on that segment
+    (and slid wholly inside the available data), so that the data being
+    analysed is always part of the data used to estimate its own PSD. This
+    avoids a spurious, position-dependent inflation of the matched-filter SNR
+    on the part of a segment that a "best overlap" PSD estimate did not see
+    (see https://github.com/gwastro/pycbc/issues/5280). A warning is emitted
+    for any segment the available data cannot fully cover.
 
     Parameters
     -----------
@@ -594,25 +627,16 @@ def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
         that precision. If 'double' the PSD will be converted to float64, if
         not already in that precision.
     """
-    psds_and_times = generate_overlapping_psds(opt, gwstrain, flen, delta_f,
-                                       flow, dyn_range_factor=dyn_range_factor,
-                                       precision=precision)
-
-    for fd_segment in fd_segments:
-        best_psd = None
-        psd_overlap = 0
-        inp_seg = segments.segment(fd_segment.seg_slice.start,
-                                   fd_segment.seg_slice.stop)
-        for start_idx, end_idx, psd in psds_and_times:
-            psd_seg = segments.segment(start_idx, end_idx)
-            if psd_seg.intersects(inp_seg):
-                curr_overlap = abs(inp_seg & psd_seg)
-                if curr_overlap > psd_overlap:
-                    psd_overlap = curr_overlap
-                    best_psd = psd
-        if best_psd is None:
-            raise ValueError("No PSDs found intersecting segment!")
-        fd_segment.psd = best_psd
+    analysis_segments = [
+        (fd_segment.seg_slice.start, fd_segment.seg_slice.stop,
+         fd_segment.seg_slice.start + fd_segment.analyze.start,
+         fd_segment.seg_slice.start + fd_segment.analyze.stop)
+        for fd_segment in fd_segments]
+    psds_and_times = generate_segment_psds(
+        opt, gwstrain, analysis_segments, flen, delta_f, flow,
+        dyn_range_factor=dyn_range_factor, precision=precision)
+    for fd_segment, (_, _, psd) in zip(fd_segments, psds_and_times):
+        fd_segment.psd = psd
 
 def associate_psds_to_single_ifo_segments(opt, fd_segments, gwstrain, flen,
                                           delta_f, flow, ifo,

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -475,30 +475,78 @@ def verify_psd_options_multi_ifo(opt, parser, ifos):
 
 
 def psd_estimation_data_length(opt, sample_rate, input_data_len):
-    """Number of samples of data used for one Welch PSD estimation"""
+    """Number of samples of data used for one Welch PSD estimation."""
     seg_stride = int(opt.psd_segment_stride * sample_rate)
     seg_len = int(opt.psd_segment_length * sample_rate)
     if opt.psd_num_segments is None:
-        num_segments = int(input_data_len // seg_stride) - 1
+        num_segments = max(int(input_data_len // seg_stride) - 1, 1)
+        if num_segments < 10:
+            logging.warning(
+                "Only %d Welch segment(s) fit in the %.0fs of data available "
+                "for PSD estimation; the PSD estimate will be noisy. Provide "
+                "more data or set --psd-num-segments explicitly.",
+                num_segments, input_data_len / sample_rate)
     else:
-        num_segments = int(opt.psd_num_segments)
+        num_segments = max(int(opt.psd_num_segments), 1)
     return (num_segments - 1) * seg_stride + seg_len
+
+
+def psd_estimation_window(psd_data_len, seg_start, seg_stop, ana_start,
+                          ana_stop, input_data_len):
+    """(start, stop) sample range of the strain to estimate one segment's PSD
+    from, given a ``psd_data_len``-sample estimation stretch.
+
+    The stretch is slid wholly inside ``[0, input_data_len]`` and placed to
+    overlap as much as possible of the data the matched filter uses for the
+    segment:
+
+      - shorter than the analysed span: centred in the analysed span;
+      - between the analysed span and the whole segment's data: covering the
+        analysed span plus as much surrounding segment data as fits, preferring
+        data before the analysed span over data after it;
+      - at least the whole segment's data: centred on the segment.
+
+    ``seg_start``/``seg_stop`` may lie outside ``[0, input_data_len]`` for
+    zero-padded edge segments; only the in-bounds part is treated as real data.
+    """
+    data_start = max(seg_start, 0)
+    data_stop = min(seg_stop, input_data_len)
+    ana_len = ana_stop - ana_start
+    data_len = data_stop - data_start
+    if psd_data_len <= ana_len:
+        psd_start = (ana_start + ana_stop - psd_data_len) // 2
+    elif psd_data_len < data_len:
+        slack = psd_data_len - ana_len
+        psd_start = ana_start - min(slack, ana_start - data_start)
+    else:
+        psd_start = (data_start + data_stop - psd_data_len) // 2
+    psd_start = min(max(psd_start, 0), input_data_len - psd_data_len)
+    return psd_start, psd_start + psd_data_len
+
+
+def _segment_bounds(fd_segment):
+    """(seg_start, seg_stop, ana_start, ana_stop) sample indices for a Fourier
+    segment, from the ``psd_seg_bounds`` set by
+    ``StrainSegments.fourier_segments`` or, for segments built elsewhere, from
+    its ``seg_slice``/``analyze`` slices.
+    """
+    try:
+        return fd_segment.psd_seg_bounds
+    except AttributeError:
+        seg, ana = fd_segment.seg_slice, fd_segment.analyze
+        return (seg.start, seg.stop,
+                seg.start + ana.start, seg.start + ana.stop)
 
 
 def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
                           dyn_range_factor=1., precision=None):
     """Estimate a PSD for each analysis segment.
 
-    For ``--psd-estimation`` the PSD for a segment is measured from a stretch of
-    strain data placed, and slid wholly inside the available data, so that it
-    overlaps as much as possible of the data the matched filter uses for that
-    segment: centred on the analysed span when shorter than it, centred on the
-    whole segment when at least as long as it, and in between covering the
-    analysed span plus as much of the surrounding segment data as fits,
-    preferring data before the analysed span over data after it.
-
-    For a static PSD (``--psd-model`` / ``--psd-file`` / ``--asd-file``) the
-    one PSD is returned for every segment.
+    For ``--psd-estimation`` each segment's PSD is measured from a stretch of
+    strain data chosen by ``psd_estimation_window`` to overlap as much as
+    possible of the data the matched filter uses for that segment. For a static
+    PSD (``--psd-model`` / ``--psd-file`` / ``--asd-file``) the one PSD is
+    returned for every segment.
 
     Parameters
     -----------
@@ -551,29 +599,14 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
     psds_and_times = []
     uncovered = []
     for seg_start, seg_stop, ana_start, ana_stop in analysis_segments:
-        # Data the matched filter actually uses for this segment, excluding any
-        # zero-padding that falls outside the available strain.
+        psd_start, psd_stop = psd_estimation_window(
+            psd_data_len, seg_start, seg_stop, ana_start, ana_stop,
+            input_data_len)
+
+        # Data the matched filter uses for this segment, excluding zero-padding
+        # outside the available strain; warn if the PSD stretch cannot span it.
         data_start = max(seg_start, 0)
         data_stop = min(seg_stop, input_data_len)
-        ana_len = ana_stop - ana_start
-        data_len = data_stop - data_start
-
-        # Position the psd_data_len-sample estimation stretch:
-        #  - shorter than the analysed span: centre it in the analysed span;
-        #  - between the analysed span and the whole segment: cover the
-        #    analysed span and spend the extra on segment data the filter uses,
-        #    preferring data before the analysed span over data after it;
-        #  - at least the whole segment: centre it on the segment.
-        if psd_data_len <= ana_len:
-            psd_start = (ana_start + ana_stop - psd_data_len) // 2
-        elif psd_data_len < data_len:
-            slack = psd_data_len - ana_len
-            psd_start = ana_start - min(slack, ana_start - data_start)
-        else:
-            psd_start = (data_start + data_stop - psd_data_len) // 2
-        psd_start = min(max(psd_start, 0), input_data_len - psd_data_len)
-        psd_stop = psd_start + psd_data_len
-
         if psd_start > data_start or psd_stop < data_stop:
             uncovered.append((data_start, data_stop, psd_start, psd_stop))
 
@@ -639,7 +672,7 @@ def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
         that precision. If 'double' the PSD will be converted to float64, if
         not already in that precision.
     """
-    analysis_segments = [fd_segment.psd_seg_bounds for fd_segment in fd_segments]
+    analysis_segments = [_segment_bounds(s) for s in fd_segments]
     psds_and_times = generate_segment_psds(
         opt, gwstrain, analysis_segments, flen, delta_f, flow,
         dyn_range_factor=dyn_range_factor, precision=precision)

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -508,7 +508,7 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
     gwstrain : TimeSeries
         The timeseries of data on which to estimate PSDs.
     analysis_segments : list of (seg_start, seg_stop, ana_start, ana_stop)
-        Sample indices into ``gwstrain`` (see ``StrainSegments.psd_segments``):
+        Sample indices into ``gwstrain`` (see ``StrainSegments.psd_segments``)
         ``seg_start``/``seg_stop`` bound the whole segment the matched filter
         uses; ``ana_start``/``ana_stop`` bound the portion analysed for
         triggers. Both are used to place each segment's PSD estimation stretch.
@@ -643,7 +643,7 @@ def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
     psds_and_times = generate_segment_psds(
         opt, gwstrain, analysis_segments, flen, delta_f, flow,
         dyn_range_factor=dyn_range_factor, precision=precision)
-    for fd_segment, (_, _, psd) in zip(fd_segments, psds_and_times):
+    for fd_segment, (_, _, psd) in zip(fd_segments, psds_and_times, strict=True):
         fd_segment.psd = psd
 
 def associate_psds_to_single_ifo_segments(opt, fd_segments, gwstrain, flen,

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -473,10 +473,9 @@ def verify_psd_options_multi_ifo(opt, parser, ifos):
                       ['--psd-segment-stride', '--psd-segment-length'],
                           required_by = "--psd-estimation")
 
+
 def psd_estimation_data_length(opt, sample_rate, input_data_len):
-    """Number of samples of data used for one ``--psd-estimation`` PSD estimate,
-    i.e. ``(psd_num_segments - 1) * psd_segment_stride + psd_segment_length``
-    (matching the convention used by ``from_cli`` / ``welch``)."""
+    """Number of samples of data used for one Welch PSD estimation"""
     seg_stride = int(opt.psd_segment_stride * sample_rate)
     seg_len = int(opt.psd_segment_length * sample_rate)
     if opt.psd_num_segments is None:
@@ -491,16 +490,15 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
     """Estimate a PSD for each analysis segment.
 
     For ``--psd-estimation`` the PSD for a segment is measured from a stretch of
-    ``gwstrain`` centred on that segment and slid wholly inside the available
-    data, so that the data being analysed is always part of the data used to
-    estimate its own PSD. This avoids a spurious, position-dependent inflation
-    of the matched-filter SNR on the part of a segment that a PSD estimate did
-    not see (see https://github.com/gwastro/pycbc/issues/5280). Segments that
-    resolve to the same data window share a PSD object, and a warning is logged
-    for any segment whose analysed span the available data cannot fully cover.
+    strain data placed, and slid wholly inside the available data, so that it
+    overlaps as much as possible of the data the matched filter uses for that
+    segment: centred on the analysed span when shorter than it, centred on the
+    whole segment when at least as long as it, and in between covering the
+    analysed span plus as much of the surrounding segment data as fits,
+    preferring data before the analysed span over data after it.
 
-    For a static PSD (``--psd-model`` / ``--psd-file`` / ``--asd-file``) the one
-    PSD is returned for every segment.
+    For a static PSD (``--psd-model`` / ``--psd-file`` / ``--asd-file``) the
+    one PSD is returned for every segment.
 
     Parameters
     -----------
@@ -510,9 +508,10 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
     gwstrain : TimeSeries
         The timeseries of data on which to estimate PSDs.
     analysis_segments : list of (seg_start, seg_stop, ana_start, ana_stop)
-        Sample indices into ``gwstrain``: ``seg_start``/``seg_stop`` bound the
-        analysis segment; ``ana_start``/``ana_stop`` bound the portion analysed
-        for triggers and are used only to decide whether to warn about coverage.
+        Sample indices into ``gwstrain`` (see ``StrainSegments.psd_segments``):
+        ``seg_start``/``seg_stop`` bound the whole segment the matched filter
+        uses; ``ana_start``/``ana_stop`` bound the portion analysed for
+        triggers. Both are used to place each segment's PSD estimation stretch.
     flen : int
         The length in samples of the output PSDs.
     delta_f : float
@@ -521,7 +520,7 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
         The low frequency cutoff to use when calculating the PSD, in hertz.
     dyn_range_factor : {1, float}
         For PSDs taken from models or text files, the PSD is multiplied by
-        ``dyn_range_factor ** 2``.
+        ``dyn_range_factor ** 2`` (default 1).
     precision : str, choices (None,'single','double')
         Precision of the returned PSDs (see ``from_cli``).
 
@@ -529,8 +528,8 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
     --------
     psds_and_times : list of (start, end, PSD) tuples
         One entry per input segment, in the same order. ``start`` and ``end``
-        are the ``gwstrain`` sample range used to estimate that segment's PSD;
-        ``PSD`` objects are shared between segments with the same window.
+        are the ``gwstrain`` sample range used to estimate that segment's PSD
+        (shared between segments that resolve to the same range).
     """
     if not opt.psd_estimation:
         psd = from_cli(opt, flen, delta_f, flow, strain=gwstrain,
@@ -552,15 +551,31 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
     psds_and_times = []
     uncovered = []
     for seg_start, seg_stop, ana_start, ana_stop in analysis_segments:
-        # Centre the PSD-estimation stretch on the analysis segment, then slide
-        # it wholly inside the available data.
-        centre = (seg_start + seg_stop) // 2
-        psd_start = min(max(centre - psd_data_len // 2, 0),
-                        input_data_len - psd_data_len)
+        # Data the matched filter actually uses for this segment, excluding any
+        # zero-padding that falls outside the available strain.
+        data_start = max(seg_start, 0)
+        data_stop = min(seg_stop, input_data_len)
+        ana_len = ana_stop - ana_start
+        data_len = data_stop - data_start
+
+        # Position the psd_data_len-sample estimation stretch:
+        #  - shorter than the analysed span: centre it in the analysed span;
+        #  - between the analysed span and the whole segment: cover the
+        #    analysed span and spend the extra on segment data the filter uses,
+        #    preferring data before the analysed span over data after it;
+        #  - at least the whole segment: centre it on the segment.
+        if psd_data_len <= ana_len:
+            psd_start = (ana_start + ana_stop - psd_data_len) // 2
+        elif psd_data_len < data_len:
+            slack = psd_data_len - ana_len
+            psd_start = ana_start - min(slack, ana_start - data_start)
+        else:
+            psd_start = (data_start + data_stop - psd_data_len) // 2
+        psd_start = min(max(psd_start, 0), input_data_len - psd_data_len)
         psd_stop = psd_start + psd_data_len
 
-        if psd_start > ana_start or psd_stop < ana_stop:
-            uncovered.append((ana_start, ana_stop, psd_start, psd_stop))
+        if psd_start > data_start or psd_stop < data_stop:
+            uncovered.append((data_start, data_stop, psd_start, psd_stop))
 
         if (psd_start, psd_stop) not in cache:
             cache[(psd_start, psd_stop)] = from_cli(
@@ -577,8 +592,8 @@ def generate_segment_psds(opt, gwstrain, analysis_segments, flen, delta_f, flow,
             "uncovered edge(s) will be slightly over-estimated. Increase "
             "--psd-num-segments (or analyse more data) so that "
             "(psd-num-segments - 1) * psd-segment-stride + psd-segment-length "
-            ">= the analysis segment length. First affected segment: analysed "
-            "[%.1f, %.1f] but PSD estimated from [%.1f, %.1f].",
+            ">= the segment length. First affected segment: data used spans "
+            "[%.1f, %.1f] but its PSD was estimated from [%.1f, %.1f].",
             len(uncovered), len(analysis_segments),
             epoch + a0 / sample_rate, epoch + a1 / sample_rate,
             epoch + p0 / sample_rate, epoch + p1 / sample_rate)
@@ -590,14 +605,11 @@ def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
     """Measure a PSD for every analysis segment and store it on the segment.
 
     With ``--psd-model``, ``--psd-file`` or ``--asd-file`` a single PSD is used
-    for every segment. With ``--psd-estimation`` the PSD for each analysis
-    segment is measured from a stretch of ``gwstrain`` centred on that segment
-    (and slid wholly inside the available data), so that the data being
-    analysed is always part of the data used to estimate its own PSD. This
-    avoids a spurious, position-dependent inflation of the matched-filter SNR
-    on the part of a segment that a "best overlap" PSD estimate did not see
-    (see https://github.com/gwastro/pycbc/issues/5280). A warning is emitted
-    for any segment the available data cannot fully cover.
+    for every segment. With ``--psd-estimation`` each segment's PSD is measured
+    from a stretch of ``gwstrain`` placed to overlap as much as possible of the
+    data the matched filter uses for that segment (see ``generate_segment_psds``),
+    so the data being analysed is always part of the data used to estimate its
+    PSD.
 
     Parameters
     -----------
@@ -627,11 +639,7 @@ def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
         that precision. If 'double' the PSD will be converted to float64, if
         not already in that precision.
     """
-    analysis_segments = [
-        (fd_segment.seg_slice.start, fd_segment.seg_slice.stop,
-         fd_segment.seg_slice.start + fd_segment.analyze.start,
-         fd_segment.seg_slice.start + fd_segment.analyze.stop)
-        for fd_segment in fd_segments]
+    analysis_segments = [fd_segment.psd_seg_bounds for fd_segment in fd_segments]
     psds_and_times = generate_segment_psds(
         opt, gwstrain, analysis_segments, flen, delta_f, flow,
         dyn_range_factor=dyn_range_factor, precision=precision)

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1191,13 +1191,27 @@ class StrainSegments(object):
         self.segment_slices = segment_slices_red
         self.analyze_slices = analyze_slices_red
 
+    def psd_segments(self):
+        """ Sample-index bounds used to associate an estimated PSD with each
+        retained analysis segment: a list of
+        ``(segment_start, segment_stop, analyse_start, analyse_stop)`` tuples,
+        one per segment and in the same order as ``segment_slices``. All four
+        values index into ``self.strain`` (``analyse_start``/``analyse_stop``
+        are offset by the segment start, unlike ``analyze_slices``).
+        """
+        return [
+            (seg.start, seg.stop, seg.start + ana.start, seg.start + ana.stop)
+            for seg, ana in zip(self.segment_slices, self.analyze_slices)
+        ]
+
     def fourier_segments(self):
         """ Return a list of the FFT'd segments.
         Return the list of FrequencySeries. Additional properties are
         added that describe the strain segment. The property 'analyze'
         is a slice corresponding to the portion of the time domain equivalent
         of the segment to analyze for triggers. The value 'cumulative_index'
-        indexes from the beginning of the original strain series.
+        indexes from the beginning of the original strain series. The property
+        'psd_seg_bounds' carries the matching entry from psd_segments().
         """
         if not self._fourier_segments:
             self._fourier_segments = []
@@ -1218,6 +1232,10 @@ class StrainSegments(object):
                 freq_seg.cumulative_index = seg_slice.start + ana.start
                 freq_seg.seg_slice = seg_slice
                 self._fourier_segments.append(freq_seg)
+
+            for freq_seg, psd_seg in zip(self._fourier_segments,
+                                         self.psd_segments()):
+                freq_seg.psd_seg_bounds = psd_seg
 
         return self._fourier_segments
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1201,7 +1201,8 @@ class StrainSegments(object):
         """
         return [
             (seg.start, seg.stop, seg.start + ana.start, seg.start + ana.stop)
-            for seg, ana in zip(self.segment_slices, self.analyze_slices)
+            for seg, ana in zip(self.segment_slices, self.analyze_slices,
+                                strict=True)
         ]
 
     def fourier_segments(self):
@@ -1234,7 +1235,7 @@ class StrainSegments(object):
                 self._fourier_segments.append(freq_seg)
 
             for freq_seg, psd_seg in zip(self._fourier_segments,
-                                         self.psd_segments()):
+                                         self.psd_segments(), strict=True):
                 freq_seg.psd_seg_bounds = psd_seg
 
         return self._fourier_segments

--- a/test/test_psd.py
+++ b/test/test_psd.py
@@ -28,6 +28,7 @@ These are the unittests for the pycbc PSD module.
 import os
 import tempfile
 from types import SimpleNamespace
+from unittest import mock
 import pycbc
 import pycbc.psd
 from pycbc.psd import (psd_estimation_window, psd_estimation_data_length,
@@ -203,16 +204,19 @@ class TestPSDSegmentPlacement(unittest.TestCase):
     def test_data_length_clamped_and_warns(self):
         # --psd-num-segments omitted, data too short for the stride -> the
         # segment count is clamped to 1 so the length is never < one Welch
-        # segment, and a warning is emitted
+        # segment, and a warning is emitted.
         opt = SimpleNamespace(psd_segment_length=4, psd_segment_stride=2,
                               psd_num_segments=None)
-        with self.assertLogs(level='WARNING'):
-            length = psd_estimation_data_length(opt, 1, 3)
-        self.assertEqual(length, 4)
-        # explicit small/zero values are also clamped to at least one segment
+        with mock.patch.object(pycbc.psd.logging, 'warning') as warn:
+            self.assertEqual(psd_estimation_data_length(opt, 1, 3), 4)
+        self.assertTrue(warn.called)
+        # explicit small/zero values are also clamped to at least one segment,
+        # without a warning
         opt = SimpleNamespace(psd_segment_length=4, psd_segment_stride=2,
                               psd_num_segments=0)
-        self.assertEqual(psd_estimation_data_length(opt, 1, 1000), 4)
+        with mock.patch.object(pycbc.psd.logging, 'warning') as warn:
+            self.assertEqual(psd_estimation_data_length(opt, 1, 1000), 4)
+        self.assertFalse(warn.called)
 
     def test_segment_bounds(self):
         from pycbc.psd import _segment_bounds

--- a/test/test_psd.py
+++ b/test/test_psd.py
@@ -27,8 +27,11 @@ These are the unittests for the pycbc PSD module.
 
 import os
 import tempfile
+from types import SimpleNamespace
 import pycbc
 import pycbc.psd
+from pycbc.psd import (psd_estimation_window, psd_estimation_data_length,
+                       generate_segment_psds)
 from pycbc.types import TimeSeries, FrequencySeries
 from pycbc.fft import ifft
 from pycbc.fft.fftw import set_measure_level
@@ -125,8 +128,139 @@ class TestPSD(unittest.TestCase):
                                 msg='seg_len=%d max_len=%d -> rms=%.3f' \
                                 % (seg_len, max_len, err_rms))
 
+class TestPSDSegmentPlacement(unittest.TestCase):
+    """Tests for associating an estimated PSD with each analysis segment."""
+
+    def setUp(self):
+        self.scheme = _scheme
+        self.context = _context
+        self.psd_low_freq_cutoff = 10.
+
+    def _white_noise(self, size, sample_freq):
+        numpy.random.seed(132435)
+        fd_size = size // 2 + 1
+        delta_f = sample_freq / size
+        noise = numpy.random.normal(size=fd_size) \
+            + 1j * numpy.random.normal(size=fd_size)
+        noise /= numpy.sqrt(delta_f) * 2
+        noise[0] = noise[0].real
+        out = TimeSeries(numpy.zeros(size), delta_t=1. / sample_freq)
+        ifft(FrequencySeries(noise, delta_f=delta_f), out)
+        return out
+
+    def test_window_shorter_than_analysed(self):
+        # PSD stretch shorter than the analysed span -> centred in it
+        start, stop = psd_estimation_window(300, 1000, 2000, 1200, 1700, 5000)
+        self.assertEqual((start, stop), (1300, 1600))
+        self.assertEqual((start + stop) // 2, (1200 + 1700) // 2)
+
+    def test_window_equal_to_analysed(self):
+        start, stop = psd_estimation_window(500, 1000, 2000, 1200, 1700, 5000)
+        self.assertEqual((start, stop), (1200, 1700))
+
+    def test_window_between_analysed_and_segment(self):
+        # covers the analysed span; spare length goes before it first
+        start, stop = psd_estimation_window(700, 1000, 2000, 1200, 1700, 5000)
+        self.assertEqual((start, stop), (1000, 1700))
+        # once the "before" side is exhausted the rest spills after
+        start, stop = psd_estimation_window(850, 1000, 2000, 1200, 1700, 5000)
+        self.assertEqual((start, stop), (1000, 1850))
+
+    def test_window_equal_to_segment(self):
+        start, stop = psd_estimation_window(1000, 1000, 2000, 1200, 1700, 5000)
+        self.assertEqual((start, stop), (1000, 2000))
+
+    def test_window_longer_than_segment(self):
+        # centred on the segment
+        start, stop = psd_estimation_window(1400, 1000, 2000, 1200, 1700, 5000)
+        self.assertEqual((start, stop), (800, 2200))
+        self.assertEqual((start + stop) // 2, (1000 + 2000) // 2)
+
+    def test_window_slides_inside_data_at_edges(self):
+        # near the start: cannot begin before sample 0
+        start, stop = psd_estimation_window(1400, 0, 1000, 100, 600, 5000)
+        self.assertEqual((start, stop), (0, 1400))
+        # near the end: cannot finish past the last sample
+        start, stop = psd_estimation_window(1400, 4000, 5000, 4200, 4700, 5000)
+        self.assertEqual((start, stop), (3600, 5000))
+
+    def test_window_with_zero_padding(self):
+        # zero-padded leading segment: seg_start < 0, analysed span reaches
+        # into the pad; the stretch must stay within the real data [0, n]
+        for pdl in (300, 600, 700, 900):
+            start, stop = psd_estimation_window(pdl, -300, 700, -100, 400, 5000)
+            self.assertGreaterEqual(start, 0)
+            self.assertLessEqual(stop, 5000)
+            self.assertEqual(stop - start, pdl)
+        # zero-padded trailing segment
+        for pdl in (300, 600, 700, 900):
+            start, stop = psd_estimation_window(pdl, 4300, 5300, 4600, 5200,
+                                                5000)
+            self.assertGreaterEqual(start, 0)
+            self.assertLessEqual(stop, 5000)
+            self.assertEqual(stop - start, pdl)
+
+    def test_data_length_clamped_and_warns(self):
+        # --psd-num-segments omitted, data too short for the stride -> the
+        # segment count is clamped to 1 so the length is never < one Welch
+        # segment, and a warning is emitted
+        opt = SimpleNamespace(psd_segment_length=4, psd_segment_stride=2,
+                              psd_num_segments=None)
+        with self.assertLogs(level='WARNING'):
+            length = psd_estimation_data_length(opt, 1, 3)
+        self.assertEqual(length, 4)
+        # explicit small/zero values are also clamped to at least one segment
+        opt = SimpleNamespace(psd_segment_length=4, psd_segment_stride=2,
+                              psd_num_segments=0)
+        self.assertEqual(psd_estimation_data_length(opt, 1, 1000), 4)
+
+    def test_segment_bounds(self):
+        from pycbc.psd import _segment_bounds
+        # from the psd_seg_bounds set by StrainSegments.fourier_segments
+        seg = SimpleNamespace(psd_seg_bounds=(10, 20, 12, 18))
+        self.assertEqual(_segment_bounds(seg), (10, 20, 12, 18))
+        # backward compatible: derive from seg_slice/analyze if that is all the
+        # segment carries (segments built the pre-psd_seg_bounds way)
+        seg = SimpleNamespace(seg_slice=slice(10, 20), analyze=slice(2, 8))
+        self.assertEqual(_segment_bounds(seg), (10, 20, 12, 18))
+
+    def test_generate_segment_psds_alignment(self):
+        sr = 4096.
+        noise = self._white_noise(262144, sr)   # 64 s
+        n = len(noise)
+        seg_len = 8192
+        ana = (1024, seg_len - 1024)
+        analysis_segments = [
+            (0, seg_len, ana[0], ana[1]),
+            (seg_len, 2 * seg_len, ana[0], ana[1]),
+            (n - seg_len, n, ana[0], ana[1]),
+            (0, seg_len, ana[0], ana[1]),   # repeat -> must reuse the PSD
+        ]
+        opt = SimpleNamespace(
+            psd_estimation='median',
+            psd_segment_length=4096 / sr, psd_segment_stride=2048 / sr,
+            psd_num_segments=4, psd_inverse_length=None,
+            psd_model=None, psd_file=None, asd_file=None,
+            psd_low_frequency_cutoff=None, invpsd_trunc_method=None)
+        flen = seg_len // 2 + 1
+        delta_f = sr / seg_len
+        with self.context:
+            out = generate_segment_psds(opt, noise, analysis_segments,
+                                        flen, delta_f, self.psd_low_freq_cutoff)
+        self.assertEqual(len(out), len(analysis_segments))
+        pdl = psd_estimation_data_length(opt, sr, n)
+        for (s0, s1, a0, a1), (start, stop, _) in zip(analysis_segments, out):
+            self.assertEqual((start, stop),
+                             psd_estimation_window(pdl, s0, s1, a0, a1, n))
+            self.assertGreaterEqual(start, 0)
+            self.assertLessEqual(stop, n)
+        # segments resolving to the same window share the PSD object
+        self.assertIs(out[0][2], out[3][2])
+
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestPSD))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestPSDSegmentPlacement))
 
 if __name__ == '__main__':
     results = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Issue #5280 showed an issue in noise triggers that is due to 1) a bad choice of PSD settings and 2) PyCBC not optimally aligning PSD segments with analysis segments. Point 1) is a configuration change, this fixes point 2) by linking the PSD assignment logic to the segments (as it was in the past).

The reason it was removed is the complication of zero padding. But given that this choice is more important than I had anticipated we add some new logic to better choose PSD segments around data even when zero padding is active.

## Standard information about the request

This is a: Scientific Improvement / Minor Bugfix

This change affects: All search codes

This change changes: scientific output

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

See the long discussion in #5280, which I won't repeat here. TL:DR, we want to better align the data used to estimate PSDs to the data segments

## Contents

There's not a whole lot here, just a change to the PSD logic. Now PSDs are not estimated independently of strain segments but are linked together. The logic for how the PSD data is chosen is:

In the case where the PSD length is *smaller* than the analysed window, we should center the PSD data within the analysed window. When PSD length is *equal* to analysed window the two should overlap. When PSD length is *greater* than analysed window, but less than data length we ingest data that is used to produce the matched-filter output, but isn't in the analysed window, there, and only there, do we prefer data before the analysed window over data after the analysed window. Once PSD length is larger than or equal to the segment length we can again center it.

pycbc_calculate_psd needs an update so it also computes PSDs following the new inspiral logic. As this is done fully within the PSD module, no changes to front end codes are needed other than calculate_psd, other codes will just pick this up. I chose to add some helper function to avoid duplication.

## Links to any issues or associated PRs

#5280

## Testing performed

Claude has done a bunch of tests based off of the 10 examples in #5280. Before this we see that even with "good" settings there are still around 100s of data that are analysed using a PSD that didn't see the data being filtered, and those times are on average about 3% louder than other times.

For the "bad" GRB example, almost half the data (in cyclical patterns) is analysed using a PSD that didn't see the data being filtered and those times (worse PSD estimation) are on average about 15% louder than other times.

With this patch the "good" settings fully cover all data being analysed, and the "bad" GRB example has somewhat reduced impact. The code will also warn in that case that things are bad.

We've checked that PSDs overlap what we expect and that calculate_psd gets the same PSDs as the inspiral jobs.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
