### PR TITLE
Bugfixes to start from samples script

### DIFF
--- a/bin/inference/pycbc_inference_start_from_samples
+++ b/bin/inference/pycbc_inference_start_from_samples
@@ -20,7 +20,7 @@ parser.add_argument('--ntemps', type=int)
 parser.add_argument('--nwalkers', type=int)
 args = parser.parse_args()
 
-init_logging(opts.verbose)
+init_logging(args.verbose)
 
 # populate an emcee start file with
 # values chosen from a dynesty file
@@ -30,7 +30,7 @@ init_logging(opts.verbose)
 ntemps = args.ntemps
 nwalkers = args.nwalkers
 
-f = loadfile(args.input_file)
+f = loadfile(args.input_file, 'r')
 params = list(f.variable_params) + ['loglikelihood']
 samples = f.read_samples(params)
 nsample = len(samples)


### PR DESCRIPTION
The `pycbc_inference_start_from_samples` script fails to run due to syntax errors in the script. I've fixed those errors here; I'm able to generate start files successfully at least with a dynesty posterior.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
