### PR TITLE
Numpy error in arbitrary distribution

### DIFF
--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -120,8 +120,10 @@ class Arbitrary(bounded.BoundedDist):
             # for scipy < 0.15.0, gaussian_kde.pdf = gaussian_kde.evaluate
             this_pdf = jacobian * self._kde.evaluate([kwargs[p]
                                                       for p in self._params])
-            if len(this_pdf) == 1:
+            if numpy.isscalar(this_pdf):
                 return float(this_pdf)
+            elif len(this_pdf) == 1:
+                return float(this_pdf.item())
             else:
                 return this_pdf
         else:


### PR DESCRIPTION
When calling the `Arbitrary` distribution from a HDF file, the following numpy error gets returned when calculating the PDF:
```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```
This looks like a remnant of some deprecated numpy behavior, where if a numpy array with one value was converted to a float, it would just return that value. This behavior now throws an error with up-to-date versions of numpy (e.g. 2.4.x). This PR fixes the function such that the PDF only gets passed to `float()` if it's actually a scalar; if it's a one-element numpy array, that array's `item()` gets passed to `float()`. This should effectively give the same behavior on older versions of numpy.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)