### PR TITLE
Try to further reduce CI failures

### DIFF
--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -18,16 +18,15 @@ jobs:
         python-version: '3.11'
     - name: install condor
       run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
         echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
+        bash tools/ci_start_condor.sh
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir ~/lal_aux_data
         pushd ~/lal_aux_data
-        curl --show-error --silent \
+        curl --show-error --silent --retry 5 --retry-delay 5 --retry-all-errors --fail \
           --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v2.0.hdf5 \
           --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
         popd
@@ -50,9 +50,7 @@ jobs:
       with:
         key: example-gw-data
         path: |
-          docs/_include/*_TDI_v2.gwf
-          docs/_include/*_GWOSC_4KHZ_R1-1126257415-4096.gwf
-          docs/_include/*_LOSC_CLN_4_V1-1187007040-2048.gwf
+          docs/_include/*.gwf
           examples/inference/lisa_smbhb_ldc/*_psd.txt
           examples/inference/lisa_smbhb_ldc/*_TDI_v2.gwf
           examples/inference/lisa_smbhb_ldc/MBHB_params_v2_LISA_frame.pkl
@@ -61,6 +59,19 @@ jobs:
           examples/inference/relative/*.gwf
           examples/inference/relmarg/*.gwf
           examples/inference/single/*.gwf
+
+    - name: Cache downloaded test data
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        key: test-data-cache-${{ hashFiles('tools/ci_prefetch_test_data.py') }}
+        restore-keys: |
+          test-data-cache-
+        path: ~/.astropy/cache/download
+
+    - name: Pre-fetch remote test data
+      continue-on-error: true
+      run: |
+        python3 tools/ci_prefetch_test_data.py
 
     - name: run pycbc test suite
       run: |

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -13,16 +13,15 @@ jobs:
         python-version: '3.11'
     - name: install condor
       run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
         echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
+        bash tools/ci_start_condor.sh
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -30,6 +30,19 @@ jobs:
       run: |
         pixi add python="${{ matrix.python-version }}.*"
 
+    - name: Cache downloaded test data
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        key: test-data-cache-${{ hashFiles('tools/ci_prefetch_test_data.py') }}
+        restore-keys: |
+          test-data-cache-
+        path: ~/.astropy/cache/download
+
+    - name: Pre-fetch remote test data
+      continue-on-error: true
+      run: |
+        python3 tools/ci_prefetch_test_data.py
+
     - name: Run basic pycbc test suite
       run: |
         pixi run -e unittest test-unittest

--- a/.github/workflows/refresh-ci-caches.yml
+++ b/.github/workflows/refresh-ci-caches.yml
@@ -1,0 +1,74 @@
+name: refresh CI caches
+
+# GitHub removes any Actions cache that has not been read for 7 days.  The data
+# caches used by basic-tests / macos basic tests are only written by the test
+# jobs themselves, so on a quiet week they expire and the next run falls back to
+# downloading everything from the origin servers (raw.githubusercontent.com,
+# zenodo.org, the pycbc_data release assets) -- exactly the flaky path we are
+# trying to avoid.
+#
+# This job runs every day: reading a cache here counts as an access and resets
+# its 7-day timer, and the caches it can build cheaply are (re)populated on a
+# miss.  It only ever touches caches on the default branch, which is where PRs
+# pick their cache fallbacks up from.
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: refresh-ci-caches
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # Populated as a side effect of the search test suite, so here we only
+      # read it to keep it from expiring.
+      - name: Touch example GW data cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          key: example-gw-data
+          path: |
+            docs/_include/*.gwf
+            examples/inference/lisa_smbhb_ldc/*_psd.txt
+            examples/inference/lisa_smbhb_ldc/*_TDI_v2.gwf
+            examples/inference/lisa_smbhb_ldc/MBHB_params_v2_LISA_frame.pkl
+            examples/inference/margtime/*.gwf
+            examples/inference/multisignal/*.gwf
+            examples/inference/relative/*.gwf
+            examples/inference/relmarg/*.gwf
+            examples/inference/single/*.gwf
+
+      - name: Cache LAL auxiliary data files
+        id: cache-lal-aux-data
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          key: lal-aux-data
+          path: ~/lal_aux_data
+
+      - if: ${{ steps.cache-lal-aux-data.outputs.cache-hit != 'true' }}
+        name: Download LAL auxiliary data files
+        run: |
+          mkdir ~/lal_aux_data
+          pushd ~/lal_aux_data
+          curl --show-error --silent --retry 5 --retry-delay 5 --retry-all-errors --fail \
+            --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v2.0.hdf5 \
+            --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
+          popd
+
+      - name: Cache downloaded test data
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          key: test-data-cache-${{ hashFiles('tools/ci_prefetch_test_data.py') }}
+          restore-keys: |
+            test-data-cache-
+          path: ~/.astropy/cache/download
+
+      - name: Pre-fetch remote test data
+        run: |
+          python3 tools/ci_prefetch_test_data.py

--- a/.github/workflows/search-splitable-workflow.yml
+++ b/.github/workflows/search-splitable-workflow.yml
@@ -20,16 +20,15 @@ jobs:
         python-version: '3.11'
     - name: install condor
       run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
         echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
+        bash tools/ci_start_condor.sh
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -20,16 +20,15 @@ jobs:
         python-version: '3.11'
     - name: install condor
       run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
         echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
+        bash tools/ci_start_condor.sh
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -17,16 +17,15 @@ jobs:
         python-version: '3.11'
     - name: install condor
       run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
         echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
+        bash tools/ci_start_condor.sh
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -26,6 +26,17 @@ jobs:
         sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl*
         pip install tox pip setuptools notebook --upgrade
         pip install .
+    - name: Cache downloaded test data
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        key: test-data-cache-${{ hashFiles('tools/ci_prefetch_test_data.py') }}
+        restore-keys: |
+          test-data-cache-
+        path: ~/.astropy/cache/download
+    - name: Pre-fetch remote test data
+      continue-on-error: true
+      run: |
+        python3 tools/ci_prefetch_test_data.py
     - name: retrieving pycbc tutorials
       run: |
         git clone https://github.com/gwastro/PyCBC-Tutorials

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -22,16 +22,15 @@ jobs:
         python-version: '3.11'
     - name: install condor
       run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
         echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
+        bash tools/ci_start_condor.sh
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
+        wget -qO - --tries=5 --retry-connrefused --waitretry=5 --timeout=30 https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24

--- a/examples/inference/lisa_smbhb_ldc/get.sh
+++ b/examples/inference/lisa_smbhb_ldc/get.sh
@@ -5,7 +5,8 @@ download_if_absent() {
     local FILENAME=$(basename "$URL")
     if [ ! -f "$FILENAME" ]; then
         echo "Downloading $FILENAME"
-        curl -O -L --show-error --silent "$URL"
+        curl -O -L --show-error --silent --retry 5 --retry-delay 2 \
+            --retry-all-errors --fail "$URL"
     else
         echo "File $FILENAME already exists, download skipped"
     fi

--- a/examples/inference/margtime/get.sh
+++ b/examples/inference/margtime/get.sh
@@ -12,6 +12,6 @@ do
 
     #curl -O -L --show-error --silent \
     #    https://www.gwosc.org/eventapi/html/GWTC-1-confident/GW150914/v3/${file}
-    curl -O -L --show-error --silent \
-	 https://media.githubusercontent.com/media/gwastro/pycbc_data/master/${file}
+    curl -O -L --show-error --silent --retry 5 --retry-delay 2 --retry-all-errors --fail \
+         https://github.com/gwastro/pycbc_data/releases/download/ci-data/${file}
 done

--- a/examples/inference/multisignal/get.sh
+++ b/examples/inference/multisignal/get.sh
@@ -12,7 +12,7 @@ do
 
 #    curl -O -L --show-error --silent https://dcc.ligo.org/public/0146/P1700349/001/${file}
 
-    curl -O -L --show-error --silent \
-         https://media.githubusercontent.com/media/gwastro/pycbc_data/master/${file}
+    curl -O -L --show-error --silent --retry 5 --retry-delay 2 --retry-all-errors --fail \
+         https://github.com/gwastro/pycbc_data/releases/download/ci-data/${file}
 
 done

--- a/examples/inference/relative/get.sh
+++ b/examples/inference/relative/get.sh
@@ -12,7 +12,7 @@ do
 
 #    curl -O -L --show-error --silent https://dcc.ligo.org/public/0146/P1700349/001/${file}
 
-    curl -O -L --show-error --silent \
-         https://media.githubusercontent.com/media/gwastro/pycbc_data/master/${file}
+    curl -O -L --show-error --silent --retry 5 --retry-delay 2 --retry-all-errors --fail \
+         https://github.com/gwastro/pycbc_data/releases/download/ci-data/${file}
 
 done

--- a/examples/inference/relmarg/get.sh
+++ b/examples/inference/relmarg/get.sh
@@ -10,7 +10,7 @@ do
 
 #    curl -O -L --show-error --silent https://dcc.ligo.org/public/0146/P1700349/001/${file}
 
-    curl -O -L --show-error --silent \
-         https://media.githubusercontent.com/media/gwastro/pycbc_data/master/${file}
+    curl -O -L --show-error --silent --retry 5 --retry-delay 2 --retry-all-errors --fail \
+         https://github.com/gwastro/pycbc_data/releases/download/ci-data/${file}
 
 done

--- a/examples/inference/single/get.sh
+++ b/examples/inference/single/get.sh
@@ -12,6 +12,6 @@ do
 
 #    curl -O -L --show-error --silent https://dcc.ligo.org/public/0146/P1700349/001/${file}
 
-    curl -O -L --show-error --silent \
-         https://media.githubusercontent.com/media/gwastro/pycbc_data/master/${file}
+    curl -O -L --show-error --silent --retry 5 --retry-delay 2 --retry-all-errors --fail \
+         https://github.com/gwastro/pycbc_data/releases/download/ci-data/${file}
 done

--- a/examples/inspiral/run.sh
+++ b/examples/inspiral/run.sh
@@ -54,7 +54,7 @@ python ./check_GW150914_detection.py H1-INSPIRAL_$1_$2_$3-OUT.hdf
 
 # Test pycbc inspiral by running over GW150914 with a limited template bank
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nv -nc https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/SMALLER_BANK_FOR_GW150914.hdf
+wget -nv -nc --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504 https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/SMALLER_BANK_FOR_GW150914.hdf
 
 echo -e "\\n\\n>> [`date`] Compressing template bank"
 pycbc_compress_bank \

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -21,6 +21,10 @@ then
         --remote-name \
         --silent \
         --show-error \
+        --retry 5 \
+        --retry-delay 2 \
+        --retry-all-errors \
+        --fail \
         https://raw.githubusercontent.com/gwastro/pycbc-config/710dbfd3590bd93d7679d7822da59fcb6b6fac0f/O2/bank/H1L1-HYPERBANK_SEOBNRv4v2_VARFLOW_THORNE-1163174417-604800.xml.gz
 
     pycbc_coinc_bank2hdf \

--- a/examples/multi_inspiral/faceon_faceaway.sh
+++ b/examples/multi_inspiral/faceon_faceaway.sh
@@ -11,7 +11,7 @@ CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspira
 INJ_FILE=faceon_faceaway_injs.hdf
 
 echo -e "\\n\\n>> [`date`] Getting injection file"
-wget -nv -nc ${CONFIG_URL}/${INJ_FILE}
+wget -nv -nc --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504 ${CONFIG_URL}/${INJ_FILE}
 
 # Generate mock data
 for IFO in 'H1' 'L1' 'V1'; do
@@ -36,9 +36,9 @@ RA="5.016076270234897 rad"
 DEC="-0.408407044967 rad"
 
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nv -nc ${CONFIG_URL}/${BANK_FILE}
+wget -nv -nc --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504 ${CONFIG_URL}/${BANK_FILE}
 echo -e "\\n\\n>> [`date`] Bank veto bank"
-wget -nv -nc ${CONFIG_URL}/${BANK_VETO_FILE}
+wget -nv -nc --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504 ${CONFIG_URL}/${BANK_VETO_FILE}
 
 for POL in 'standard' 'left' 'right' 'left+right'; do
     echo -e "\\n\\n>> [`date`] Running pycbc_multi_inspiral with ${POL} projection"

--- a/examples/multi_inspiral/gw170817_h.sh
+++ b/examples/multi_inspiral/gw170817_h.sh
@@ -5,7 +5,7 @@ set -e
 CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
 BANK_FILE=gw170817_single_template.hdf
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nv -nc ${CONFIG_URL}/${BANK_FILE}
+wget -nv -nc --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504 ${CONFIG_URL}/${BANK_FILE}
 
 EVENT=1187008882
 PAD=8

--- a/examples/multi_inspiral/gw170817_hl.sh
+++ b/examples/multi_inspiral/gw170817_hl.sh
@@ -5,7 +5,7 @@ set -e
 CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
 BANK_FILE=gw170817_single_template.hdf
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nv -nc ${CONFIG_URL}/${BANK_FILE}
+wget -nv -nc --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504 ${CONFIG_URL}/${BANK_FILE}
 
 EVENT=1187008882
 PAD=8

--- a/examples/multi_inspiral/gw170817_hlv.sh
+++ b/examples/multi_inspiral/gw170817_hlv.sh
@@ -5,7 +5,7 @@ set -e
 CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
 BANK_FILE=gw170817_single_template.hdf
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nv -nc ${CONFIG_URL}/${BANK_FILE}
+wget -nv -nc --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504 ${CONFIG_URL}/${BANK_FILE}
 
 EVENT=1187008882
 PAD=8

--- a/examples/search/get.sh
+++ b/examples/search/get.sh
@@ -10,6 +10,10 @@ set -e
 #wget -nv https://dcc.ligo.org/public/0146/P1700341/001/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
 #wget -nv https://dcc.ligo.org/public/0146/P1700341/001/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf
 
-wget -nv https://media.githubusercontent.com/media/gwastro/pycbc_data/master/H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf
-wget -nv https://media.githubusercontent.com/media/gwastro/pycbc_data/master/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
-wget -nv https://media.githubusercontent.com/media/gwastro/pycbc_data/master/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf
+# Files are hosted as GitHub release assets (not Git LFS) so downloads are not
+# rate-limited. --retry* guards against transient GitHub/CDN errors.
+BASE=https://github.com/gwastro/pycbc_data/releases/download/ci-data
+WGET="wget -nv --tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=429,500,502,503,504"
+${WGET} ${BASE}/H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf
+${WGET} ${BASE}/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
+${WGET} ${BASE}/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf

--- a/pycbc/io/__init__.py
+++ b/pycbc/io/__init__.py
@@ -1,57 +1,133 @@
 import os
+import time
 import logging
-from astropy.utils.data import download_file
-import hashlib
+from urllib.error import HTTPError
 from urllib.parse import urlparse
+import hashlib
+from astropy.utils.data import download_file
 from .hdf import *
 from .record import *
 from .gracedb import *
 
 logger = logging.getLogger('pycbc.io')
 
-# Backup URL in case GWOSC fails
+# Backup locations for the GWOSC data files used by the test suite / examples,
+# in gwastro/pycbc_data.  Binary frame/ROM files are stored as release assets
+# (not Git LFS, so downloads are not rate-limited), with the old Git-LFS media
+# location as a second fallback; the small pre-computed GWOSC JSON responses
+# are plain files in the repo, keyed by an md5 of the request URL.
 base_backup_url = "https://raw.githubusercontent.com/gwastro/pycbc_data/master/{}"
-base_lfs_backup_url = "https://media.githubusercontent.com/media/gwastro/pycbc_data/master/{}"
+base_lfs_backup_url = (
+    "https://github.com/gwastro/pycbc_data/releases/download/ci-data/{}"
+)
+base_lfs_media_url = (
+    "https://media.githubusercontent.com/media/gwastro/pycbc_data/master/{}"
+)
+
+# HTTP status codes for which retrying the same URL is pointless; move straight
+# on to the next candidate location instead of waiting and trying again.
+_NO_RETRY_HTTP_CODES = (400, 401, 403, 404, 410)
+
+# Hosts whose frame/ROM files are mirrored in gwastro/pycbc_data.  GWOSC has
+# used several names over the years (gwosc.org, gw-openscience.org,
+# losc.ligo.org) and the "cleaned" O2 strain lives on the DCC; all of them are
+# regularly unreachable or slow from GitHub Actions.
+_MIRRORED_HOSTS = (
+    "gwosc.org/",
+    "gw-openscience.org/",
+    "losc.ligo.org/",
+    "dcc.ligo.org/",
+)
+# ...of those, the ones that also serve the small GWOSC JSON API responses
+# cached (by md5 of the request URL) in gwastro/pycbc_data.
+_JSON_API_HOSTS = ("gwosc.org/", "gw-openscience.org/")
 
 
-def get_file(url, retry=5, **args):
-    """ Retrieve file with retry upon failure
+def _candidate_urls(url):
+    """Ordered list of URLs to try for ``url``.
 
-    Uses the astropy download_file but adds a retry feature for flaky
-    connections. See astropy for full options
+    Accessing GWOSC / the DCC directly from GitHub Actions frequently fails,
+    and the files the test suite / examples / tutorials ask for there are
+    exactly the ones mirrored in gwastro/pycbc_data.  So *only* inside GitHub
+    Actions, and *only* for those hosts, the mirrored copies are tried first
+    (both the release asset and the Git-LFS media copy for frame/ROM files)
+    with the original URL last.  Everywhere else ``url`` is used as given -- a
+    direct request outside Actions is very likely for a file that is not in
+    the mirror.
     """
-    i = 0
-    if os.getenv("GITHUB_ACTIONS") == "true":
-        # Accessing GWOSC from GitHub Actions is a pain and often fails.
-        # If this is in GitHub Actions we divert the URLs to a backup path
-        if "gwosc.org/" in url:
-            basename = os.path.basename(urlparse(url).path)
-            if basename.endswith('hdf5') or basename.endswith('gwf'):
-                # Just download file directly from backup
-                new_url = base_lfs_backup_url.format(basename)
+    if (os.getenv("GITHUB_ACTIONS") == "true"
+            and any(host in url for host in _MIRRORED_HOSTS)):
+        basename = os.path.basename(urlparse(url).path)
+        if basename.endswith(('gwf', 'hdf5')):
+            candidates = [
+                base_lfs_backup_url.format(basename),
+                base_lfs_media_url.format(basename),
+                url,
+            ]
+        elif any(host in url for host in _JSON_API_HOSTS):
+            hh = hashlib.md5(url.strip().lower().encode('utf-8')).hexdigest()
+            candidates = [base_backup_url.format(hh + '.json'), url]
+        else:
+            candidates = [url]
+    else:
+        candidates = [url]
+
+    # de-duplicate while preserving order
+    seen = set()
+    return [c for c in candidates if not (c in seen or seen.add(c))]
+
+
+def get_file(url, retry=5, backoff_cap=5, **args):
+    """Retrieve a file, retrying with back-off and falling back to backups.
+
+    Wraps :func:`astropy.utils.data.download_file`, adding bounded
+    exponential back-off between attempts and, for GWOSC / DCC URLs fetched
+    from GitHub Actions, automatic fall-back to the mirrored copies in
+    gwastro/pycbc_data.  A definitive HTTP error (e.g. a 404) moves straight
+    on to the next location instead of retrying, so genuine "not found"
+    failures are reported quickly.  See astropy for the full set of keyword
+    options.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the file to retrieve.
+    retry : int
+        Maximum number of attempts per candidate location.
+    backoff_cap : int
+        Upper bound, in seconds, on the wait between attempts.
+    """
+    if retry < 1:
+        raise ValueError(f"retry must be a positive integer, got {retry}")
+    candidates = _candidate_urls(url)
+    last_exc = None
+    for cand in candidates:
+        if cand != url:
+            logger.warning("Redirecting %s to backup location %s", url, cand)
+        for i in range(1, retry + 1):
+            try:
+                return download_file(cand, **args)
+            except HTTPError as exc:
+                last_exc = exc
+                if exc.code in _NO_RETRY_HTTP_CODES:
+                    logger.warning(
+                        "%s returned HTTP %d; not retrying this location",
+                        cand, exc.code
+                    )
+                    break
                 logger.warning(
-                    "Redirecting GWOSC URL %s to backup url %s",
-                    url,
-                    new_url
+                    "Failed on attempt %d to download %s (HTTP %d)",
+                    i, cand, exc.code
                 )
-                url = new_url
-            else:
-                cleaned_url = url.strip().lower()
-                hash_object = hashlib.md5(cleaned_url.encode('utf-8'))
-                hh = hash_object.hexdigest()
-                new_url = base_backup_url.format(hh + '.json')
+            except Exception as exc:
+                # Any other failure (URLError, ContentTooShortError, socket
+                # timeout, ...) is treated as transient and retried.
+                last_exc = exc
                 logger.warning(
-                    "Redirecting GWOSC URL %s to backup url %s",
-                    url,
-                    new_url
+                    "Failed on attempt %d to download %s (%s)",
+                    i, cand, type(exc).__name__
                 )
-                url = new_url
-    while True:
-        i += 1
-        try:
-            return download_file(url, **args)
-        except Exception as e:
-            logger.warning("Failed on attempt %d to download %s", i, url)
-            if i >= retry:
-                logger.error("Giving up on %s", url)
-                raise e
+            if i < retry:
+                time.sleep(min(backoff_cap, 2 ** i))
+    logger.error("Giving up on %s", url)
+    raise last_exc

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -917,13 +917,13 @@ def averaged_lisa_fplus_sq_numerical(f, len_arm=2.5e9):
     -----
         Please see Eq.(36) in <LISA-LCST-SGS-TN-001> for more details.
     """
-    from astropy.utils.data import download_file
+    from pycbc.io import get_file
 
     if len_arm != 2.5e9:
         raise ValueError("Currently only support 'len_arm=2.5e9'.")
     # Download the numerical LISA averaged response.
     url = "https://zenodo.org/record/7497853/files/AvFXp2_Raw.npy"
-    file_path = download_file(url, cache=True)
+    file_path = get_file(url, cache=True)
     freqs, fp_sq = np.load(file_path)
     # Padding the end.
     freqs = np.append(freqs, 2)

--- a/test/test_bhspec.py
+++ b/test/test_bhspec.py
@@ -35,10 +35,11 @@ class TestBHSpecModel(unittest.TestCase):
             frame_file = frame_file.split(":")[-1]
             if not os.path.exists(frame_file):
                 url = os.path.join(cls.frame_files_url, frame_file)
-                tmp_path = get_file(url, cache=False)
-                # Naming matters here, so we move the file to something named
-                # in accordance with the frame-file specification.
-                shutil.move(tmp_path, frame_file)
+                tmp_path = get_file(url, cache=True)
+                # Naming matters here, so we copy the file to something named
+                # in accordance with the frame-file specification (copy rather
+                # than move so the astropy download cache stays intact).
+                shutil.copy(tmp_path, frame_file)
 
         # Load expected parameter values and expected loglikelihood from
         # the JSON file

--- a/test/test_frame.py
+++ b/test/test_frame.py
@@ -28,7 +28,7 @@ These are the unittests for the pycbc frame/cache reading functions
 
 import unittest
 import numpy
-from astropy.utils.data import download_file
+from pycbc.io import get_file
 
 import pycbc
 import pycbc.frame
@@ -65,7 +65,7 @@ class FrameTestBase(unittest.TestCase):
         # This is a file in the temp directory that will be deleted when it is garbage collected
         url = 'https://github.com/gwastro/pycbc-config/raw/master/'
         url += 'test_data_files/frametest{}.gwf'
-        filename = download_file(url.format(self.data1.dtype), cache=True)
+        filename = get_file(url.format(self.data1.dtype), cache=True)
 
         # Make sure we can run from one directory higher as well
         import os.path

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -35,7 +35,7 @@ from pycbc.psd import interpolate, inverse_spectrum_truncation, aLIGOZeroDetHigh
 from pycbc.noise import noise_from_psd
 from pycbc.frame import read_frame
 from pycbc.filter import highpass, resample_to_delta_t
-from astropy.utils.data import download_file
+from pycbc.io import get_file
 from pycbc.inference import models
 from pycbc.distributions import Uniform, JointDistribution, SinAngle, UniformAngle
 from pycbc.waveform.waveform import FailedWaveformError
@@ -57,9 +57,9 @@ class TestModels(unittest.TestCase):
             # Not using dcc.ligo.org because it sometimes hangs in the test
             # suite. But original URL is commented below
             # url = "https://dcc.ligo.org/public/0146/P1700349/001/"
-            url = "https://media.githubusercontent.com/media/gwastro/pycbc_data/master/"
+            url = "https://github.com/gwastro/pycbc_data/releases/download/ci-data/"
             url += "{}-{}1_LOSC_CLN_4_V1-1187007040-2048.gwf"
-            fname = download_file(url.format(ifo[0], ifo[0]), cache=True)
+            fname = get_file(url.format(ifo[0], ifo[0]), cache=True)
             ts = read_frame(fname, "{}:LOSC-STRAIN".format(ifo),
                             start_time=int(m.time - 260),
                             end_time=int(m.time + 40))

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import numpy as np
 import h5py
 import logging
-from astropy.utils.data import download_file
+from pycbc.io import get_file
 from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
 from utils import simple_exit
 import validation_code.old_coinc as old_coinc
@@ -72,7 +72,7 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         url = 'https://github.com/gwastro/pycbc-config/raw/master/'
         url += 'test_data_files/{}-PTA_HISTOGRAM.hdf'
         stat_file_paths = [
-            download_file(url.format("H1L1"), cache=True),
+            get_file(url.format("H1L1"), cache=True),
         ]
         args = SimpleNamespace(
             sngl_ranking="snr",

--- a/test/test_skymax.py
+++ b/test/test_skymax.py
@@ -290,7 +290,7 @@ class TestChisq(unittest.TestCase):
         url = ('https://github.com/gwastro/pycbc-config/raw/master/'
                'test_data_files/{}')
         fname = f'skymaxtest_stilde_{idx}.hdf'
-        apy_fname = get_file(url.format(fname), cache=False)
+        apy_fname = get_file(url.format(fname), cache=True)
         # Astropy will not download with the .hdf extension, which we need,
         # so symlink
         os.symlink(apy_fname, fname)
@@ -311,7 +311,7 @@ class TestChisq(unittest.TestCase):
         #except:
         #    pass
         fname = f'skymaxtest_hplus_{jdx}.hdf'
-        apy_fname = get_file(url.format(fname), cache=False)
+        apy_fname = get_file(url.format(fname), cache=True)
         # Astropy will not download with the .hdf extension, which we need,
         # so symlink
         os.symlink(apy_fname, fname)
@@ -319,7 +319,7 @@ class TestChisq(unittest.TestCase):
         os.unlink(fname)
 
         fname = f'skymaxtest_hcross_{jdx}.hdf'
-        apy_fname = get_file(url.format(fname), cache=False)
+        apy_fname = get_file(url.format(fname), cache=True)
         # Astropy will not download with the .hdf extension, which we need,
         # so symlink
         os.symlink(apy_fname, fname)

--- a/test/test_skymax.py
+++ b/test/test_skymax.py
@@ -5,7 +5,7 @@ import os
 import numpy
 from numpy import complex128, real, sqrt, sin, cos, angle, ceil, log
 from numpy import zeros, argmax, array
-from astropy.utils.data import download_file
+from pycbc.io import get_file
 from pycbc import DYN_RANGE_FAC
 from pycbc.waveform import get_td_waveform, get_fd_waveform, td_approximants, fd_approximants
 from pycbc.pnutils import nearest_larger_binary_number
@@ -290,7 +290,7 @@ class TestChisq(unittest.TestCase):
         url = ('https://github.com/gwastro/pycbc-config/raw/master/'
                'test_data_files/{}')
         fname = f'skymaxtest_stilde_{idx}.hdf'
-        apy_fname = download_file(url.format(fname), cache=False)
+        apy_fname = get_file(url.format(fname), cache=False)
         # Astropy will not download with the .hdf extension, which we need,
         # so symlink
         os.symlink(apy_fname, fname)
@@ -311,7 +311,7 @@ class TestChisq(unittest.TestCase):
         #except:
         #    pass
         fname = f'skymaxtest_hplus_{jdx}.hdf'
-        apy_fname = download_file(url.format(fname), cache=False)
+        apy_fname = get_file(url.format(fname), cache=False)
         # Astropy will not download with the .hdf extension, which we need,
         # so symlink
         os.symlink(apy_fname, fname)
@@ -319,7 +319,7 @@ class TestChisq(unittest.TestCase):
         os.unlink(fname)
 
         fname = f'skymaxtest_hcross_{jdx}.hdf'
-        apy_fname = download_file(url.format(fname), cache=False)
+        apy_fname = get_file(url.format(fname), cache=False)
         # Astropy will not download with the .hdf extension, which we need,
         # so symlink
         os.symlink(apy_fname, fname)

--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -201,12 +201,12 @@ class TmpltbankTestClass(unittest.TestCase):
 
     def test_eigen_directions(self):
         fname='stockEvals.dat.gz'
-        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=True)
         with gzip.open(apy_fname) as apy_fp:
             evalsStock = Array(numpy.loadtxt(apy_fp))
 
         fname='stockEvecs.dat.gz'
-        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=True)
         with gzip.open(apy_fname) as apy_fp:
             evecsStock = Array(numpy.loadtxt(apy_fp))
 
@@ -419,7 +419,7 @@ class TmpltbankTestClass(unittest.TestCase):
         chirps=pycbc.tmpltbank.get_chirp_params(2.2, 1.8, 0.2, 0.3,
                               self.metricParams.f0, self.metricParams.pnOrder)
         fname = 'stockChirps.dat.gz'
-        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=True)
         with gzip.open(apy_fname) as apy_fp:
             stockChirps = numpy.loadtxt(apy_fp)
         diff = (chirps - stockChirps) / stockChirps
@@ -430,7 +430,7 @@ class TmpltbankTestClass(unittest.TestCase):
         arrz = pycbc.tmpltbank.generate_hexagonal_lattice(10, 0, 10, 0, 0.03)
         arrz = numpy.array(arrz)
         fname = 'stockHexagonal.dat.gz'
-        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=True)
         with gzip.open(apy_fname) as apy_fp:
             stockGrid = numpy.loadtxt(apy_fp)
         diff = arrz - stockGrid
@@ -442,7 +442,7 @@ class TmpltbankTestClass(unittest.TestCase):
                                                           10, 0.03)
         arrz = numpy.array(arrz)
         fname = 'stockAnstar3D.dat.gz'
-        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=True)
         with gzip.open(apy_fname) as apy_fp:
             stockGrid = numpy.loadtxt(apy_fp)
         # Uncomment this line to regenerate the data file

--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -28,8 +28,8 @@ These are the unittests for the pycbc.tmpltbank module
 import math
 import gzip
 import numpy
-from astropy.utils.data import download_file
 from astropy.utils.data import conf
+from pycbc.io import get_file
 import pycbc.tmpltbank
 # Old LigoLW output functions are not imported at tmpltbank level
 import pycbc.tmpltbank.bank_output_utils as llw_output
@@ -135,7 +135,7 @@ class TmpltbankTestClass(unittest.TestCase):
         self.segLen = 1./self.deltaF
         self.psdSize = int(self.segLen * self.sampleRate / 2.) + 1
 
-        apy_fname = download_file(
+        apy_fname = get_file(
             DATA_FILE_URL.format('ZERO_DET_high_P.txt.gz'),
             cache=True
         )
@@ -201,12 +201,12 @@ class TmpltbankTestClass(unittest.TestCase):
 
     def test_eigen_directions(self):
         fname='stockEvals.dat.gz'
-        apy_fname = download_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
         with gzip.open(apy_fname) as apy_fp:
             evalsStock = Array(numpy.loadtxt(apy_fp))
 
         fname='stockEvecs.dat.gz'
-        apy_fname = download_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
         with gzip.open(apy_fname) as apy_fp:
             evecsStock = Array(numpy.loadtxt(apy_fp))
 
@@ -419,7 +419,7 @@ class TmpltbankTestClass(unittest.TestCase):
         chirps=pycbc.tmpltbank.get_chirp_params(2.2, 1.8, 0.2, 0.3,
                               self.metricParams.f0, self.metricParams.pnOrder)
         fname = 'stockChirps.dat.gz'
-        apy_fname = download_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
         with gzip.open(apy_fname) as apy_fp:
             stockChirps = numpy.loadtxt(apy_fp)
         diff = (chirps - stockChirps) / stockChirps
@@ -430,7 +430,7 @@ class TmpltbankTestClass(unittest.TestCase):
         arrz = pycbc.tmpltbank.generate_hexagonal_lattice(10, 0, 10, 0, 0.03)
         arrz = numpy.array(arrz)
         fname = 'stockHexagonal.dat.gz'
-        apy_fname = download_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
         with gzip.open(apy_fname) as apy_fp:
             stockGrid = numpy.loadtxt(apy_fp)
         diff = arrz - stockGrid
@@ -442,7 +442,7 @@ class TmpltbankTestClass(unittest.TestCase):
                                                           10, 0.03)
         arrz = numpy.array(arrz)
         fname = 'stockAnstar3D.dat.gz'
-        apy_fname = download_file(DATA_FILE_URL.format(fname), cache=False)
+        apy_fname = get_file(DATA_FILE_URL.format(fname), cache=False)
         with gzip.open(apy_fname) as apy_fp:
             stockGrid = numpy.loadtxt(apy_fp)
         # Uncomment this line to regenerate the data file

--- a/tools/ci_prefetch_test_data.py
+++ b/tools/ci_prefetch_test_data.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Pre-seed the astropy download cache with the remote data files used by the
+unit-test suite and the tutorial-notebook tests.
+
+Those pull data files from the pycbc-config repo and the pycbc_data release
+assets via ``pycbc.io.get_file`` / ``astropy.utils.data.download_file(...,
+cache=True)``.  On a cold CI cache every job re-downloads them, and a
+transient raw.githubusercontent.com / GitHub error then fails the job.
+
+Running this script populates ``~/.astropy/cache/download`` directly (it only
+needs the Python standard library, not pycbc or astropy).  That directory is
+persisted with ``actions/cache`` and refreshed daily by the
+``refresh-ci-caches`` workflow, so test runs get cache hits instead.
+
+Keep ``URLS`` in step with the tests that download with ``cache=True``.
+Downloading is best effort: ``get_file`` still retries at test time, and a
+miss just means the test fetches the file itself.
+"""
+
+import hashlib
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+PYCBC_CONFIG = (
+    "https://github.com/gwastro/pycbc-config/raw/master/test_data_files/{}"
+)
+RELEASE = "https://github.com/gwastro/pycbc_data/releases/download/ci-data/{}"
+
+URLS = []
+
+# test/test_frame.py
+URLS += [
+    PYCBC_CONFIG.format(f"frametest{dtype}.gwf")
+    for dtype in ("float32", "float64", "complex64", "complex128")
+]
+
+# test/test_skymax.py  (idx, jdx both range(4))
+URLS += [
+    PYCBC_CONFIG.format(f"skymaxtest_{kind}_{i}.hdf")
+    for kind in ("stilde", "hplus", "hcross")
+    for i in range(4)
+]
+
+# test/test_tmpltbank.py
+URLS += [
+    PYCBC_CONFIG.format(name)
+    for name in (
+        "ZERO_DET_high_P.txt.gz",
+        "stockEvals.dat.gz",
+        "stockEvecs.dat.gz",
+        "stockChirps.dat.gz",
+        "stockHexagonal.dat.gz",
+        "stockAnstar3D.dat.gz",
+    )
+]
+
+# test/test_live_coinc_compare.py
+URLS += [PYCBC_CONFIG.format("H1L1-PTA_HISTOGRAM.hdf")]
+
+# test/test_infmodel.py
+URLS += [
+    RELEASE.format(f"{ifo}-{ifo}1_LOSC_CLN_4_V1-1187007040-2048.gwf")
+    for ifo in "HLV"
+]
+
+# test/test_bhspec.py
+URLS += [
+    RELEASE.format(f"{ifo}-{ifo}1_GWOSC_4KHZ_R1-1126259447-32.gwf")
+    for ifo in "HL"
+]
+
+# PyCBC-Tutorials notebooks run in the "tutorial tests" workflow.  They pass
+# get_file the original GWOSC / DCC URL, which (inside Actions) is fetched from
+# the release asset -- so key the cache on the release URL.  The LOSC_CLN 2048s
+# files inference_0 / inference_1 use are already listed above for
+# test/test_infmodel.py.
+URLS += [
+    RELEASE.format(name)
+    for name in (
+        "H-H1_LOSC_4_V2-1126259446-32.gwf",   # examples/gw150914_audio
+        "L-L1_LOSC_4_V2-1135136334-32.gwf",   # examples/gw151226_snr
+        "H-H1_LOSC_4_V1-1167559920-32.gwf",   # examples/gw170104_look
+        "L-L1_LOSC_4_V1-1167559920-32.gwf",   # examples/gw170104_look
+        "H-H1_LOSC_4_V2-1128678884-32.gwf",   # tutorial/1_CatalogData
+    )
+]
+URLS += [
+    RELEASE.format(f"{ifo}-{ifo}1_GWOSC_4KHZ_R2-1242440920-4096.gwf")
+    for ifo in "HLV"                          # tutorial/inference_8_BHRingdown
+]
+
+CACHE_DIR = os.path.join(
+    os.path.expanduser("~"), ".astropy", "cache", "download", "url"
+)
+
+
+def _url_to_dirname(url):
+    """Reproduce astropy.utils.data._url_to_dirname."""
+    parts = list(urllib.parse.urlsplit(url))
+    parts[1] = parts[1].lower()
+    if parts[0].lower() in ("http", "https") and parts[1] and parts[2] == "":
+        parts[2] = "/"
+    normalised = urllib.parse.urlunsplit(parts)
+    return hashlib.md5(normalised.encode("utf-8")).hexdigest()
+
+
+def prefetch(url, attempts=5):
+    entry = os.path.join(CACHE_DIR, _url_to_dirname(url))
+    contents = os.path.join(entry, "contents")
+    if os.path.exists(contents):
+        return "cached"
+    os.makedirs(entry, exist_ok=True)
+    last_exc = None
+    for i in range(1, attempts + 1):
+        try:
+            req = urllib.request.Request(
+                url, headers={"User-Agent": "pycbc-ci-prefetch"}
+            )
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = resp.read()
+            tmp = contents + ".tmp"
+            with open(tmp, "wb") as fh:
+                fh.write(data)
+            os.replace(tmp, contents)
+            with open(os.path.join(entry, "url"), "w") as fh:
+                fh.write(url)
+            return "ok"
+        except Exception as exc:  # best effort
+            last_exc = exc
+            if i < attempts:
+                time.sleep(min(5, 2 ** i))
+    raise last_exc
+
+
+def main():
+    failures = []
+    for url in URLS:
+        try:
+            status = prefetch(url)
+            print(f"{status:6s} {url}")
+        except Exception as exc:
+            failures.append(url)
+            print(f"FAIL   {url}  ({exc})")
+    if failures:
+        print(f"\n{len(failures)}/{len(URLS)} downloads failed")
+        return 1
+    print(f"\nall {len(URLS)} test-data files present in cache")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci_start_condor.sh
+++ b/tools/ci_start_condor.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Start HTCondor and wait until its scheduler (schedd) is reachable.
+#
+# minihtcondor must already be installed.  Used by the pegasus + condor CI
+# workflows.  On a fresh runner condor.service sometimes comes up "active" but
+# with no daemons actually running (condor_master is alive, but there is no
+# schedd); a workflow submit then fails later with the cryptic
+#   ERROR: Can't find address of local schedd
+# so here we make the hostname resolvable, start condor, and restart it a few
+# times until `condor_q` succeeds, dumping the condor logs if it never does.
+
+# The condor daemons fail to start if the machine's own hostname does not
+# resolve.
+if ! grep -q "$(hostname)" /etc/hosts; then
+    echo "127.0.1.1 $(hostname)" | sudo tee -a /etc/hosts
+fi
+
+sudo systemctl enable condor
+
+for start in 1 2 3; do
+    sudo systemctl restart condor
+    for poll in $(seq 1 20); do
+        if condor_q > /dev/null 2>&1; then
+            echo "condor schedd ready (start ${start}, after ${poll} polls)"
+            condor_status
+            exit 0
+        fi
+        echo "waiting for condor schedd (start ${start}, poll ${poll}/20)..."
+        sleep 3
+    done
+    echo "condor schedd still not up after start ${start}"
+    sudo systemctl status condor --no-pager
+    sudo tail -n 50 /var/log/condor/MasterLog 2>/dev/null
+done
+
+echo "::error::condor schedd did not become ready"
+sudo systemctl status condor --no-pager
+sudo journalctl -u condor --no-pager | tail -n 50
+sudo tail -n 100 /var/log/condor/MasterLog /var/log/condor/SchedLog 2>/dev/null
+exit 1


### PR DESCRIPTION
We've still been seeing numerous transient failures in the CI over the last few months. Ignoring ones where issues are already fixed I had Claude investigate logs from as many of the recent CI runs as it could easily access and summarize the problems:

* We have failures trying to download from the pycbc_data replacement to GWOSC. Here Claude recommended moving this to a github release (which is apparently more available than LFS) and perhaps also using GWOSC / LFS as fallbacks if one path fails.
* Some of these failures come from the PyCBC_Tutorials repository, this is *not* addressed here, but we can keep on eye on if we continue to see failures there and update calls as needed.
* There is also a suggestion to cache a bunch of the input files, as we are basically accessing the same things every time.
* One of the tests (test_skymax) is calling astropy directly, Claude thinks it is not retrying (though I am not so sure).
* There are issues with condor not being available when workflows start. Claude (and I agree having checked the logs) isn't so clear on why this is happening, possibly a race issue where the service hasn't started when the submission happens.

This PR then makes some changes to try to improve these things to improve resilience of the CI. After this is merged we could then run a similar test 3 months later and see if issues remain.

## Standard information about the request

This is a: CI stability improvement

This change affects: the CI 

This change changes: CI

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

The CI failing is annoying and slows down work.

## Contents

* The "get condor running in the CI" code adds some reduncancy to the apt-get command, and puts a test upfront to make sure than condor is working *before* anything pegasus/PyCBC is invoked. (At least if this remains a problem it is now clearer)
* Zenodo downloads in basic_tests will now retry.
* Add more robust caching. I'm not too sure I know how all this works internally, but the idea is a daily new `refresh-ci-caches.yml` workflow downloads all the needed files and ensures they are cached for the other jobs to pick this up. If the cache fails or a file is not available, it will be downloaded normally (using astropy's existing functionality for this). 
* Some inference examples using curl now have extra safeguarding/redundancy on that call
* download_file -> get_file in a bunch of cases
* The get_file function now does some additional backup trying, and in the CI can *fallback to GWOSC* if github fails.

## Testing performed

It's hard to test this before merging, as on my laptop the tests run fine. The proof will have to be in first making sure that the CI works here and then monitoring this over the next month to see if these issues decrease.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
