### PR TITLE
Test and build for Python 3.14

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 60
       matrix:
         os: [ubuntu-24.04]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         test-type: [unittest, search, docs]
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp311-* cp312-* cp313-*
+          CIBW_BUILD: cp311-* cp312-* cp313-* cp314-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_MACOS: x86_64 arm64
       - name: Upload wheels

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
 
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -33,6 +33,12 @@ from pycbc.inference import models
 from pycbc.inference.io import loadfile
 from pycbc.workflow import configuration
 
+from pycbc.pool import use_fork_start_method
+
+# cpnest builds its own pool rather than taking ours, and its children
+# read what this process already has, so the start method is set here
+use_fork_start_method()
+
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -23,13 +23,14 @@ hdf file."""
 import argparse
 import numpy
 import logging
-import multiprocessing
 
 import pycbc
 import pycbc.psd
 from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import real_same_precision_as
+from pycbc.pool import BroadcastPool
+
 
 # --- WORKER FUNCTION ---
 def _worker(ii):
@@ -207,7 +208,7 @@ if __name__ == "__main__":
 
     logging.info("Starting compression with %d processes", args.nprocesses)
     
-    pool = multiprocessing.Pool(processes=args.nprocesses)
+    pool = BroadcastPool(processes=args.nprocesses)
     results = pool.imap_unordered(_worker, range(bank_table.size))
 
     for result in results:

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -1,6 +1,7 @@
 """ Tools for creating pools of worker processes
 """
 import multiprocessing.pool
+import sys
 import functools
 from multiprocessing import TimeoutError, cpu_count, get_context
 import types
@@ -9,6 +10,19 @@ import atexit
 import logging
 
 logger = logging.getLogger('pycbc.pool')
+
+
+def use_fork_start_method():
+    """ Set fork as the multiprocessing start method, for pools we do not make
+
+    Does nothing if a start method has already been chosen, or where fork was
+    not the default to begin with.
+    """
+    if (sys.platform.startswith('linux')
+            and 'fork' in multiprocessing.get_all_start_methods()
+            and multiprocessing.get_start_method(allow_none=True) is None):
+        multiprocessing.set_start_method('fork')
+
 
 def is_main_process():
     """ Check if this is the main control process and may handle one time tasks

--- a/setup.py
+++ b/setup.py
@@ -277,6 +277,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Intended Audience :: Science/Research',
         'Natural Language :: English',
         'Topic :: Scientific/Engineering',


### PR DESCRIPTION
Enable 3.14 builds and testing

## Standard information about the request

This is just a change to the testing / distribution at the moment. If anything pops up in the build some changes to the library may be needed. 

## Motivation
3.14 has been out for a long time, other libraries should have built versions, so I suspect this will just work now and we should add support. 

## Testing performed
The basic unittests worked on my laptop, but this will hopefully run the full CI and see if the wheels build. 


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
