### PR TITLE
Use LAL's PN Coefficients for findchirp_chirptime

### DIFF
--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -659,11 +659,12 @@ def get_inspiral_tf(
     if approximant in ["TaylorF2", "SPAtmplt"]:
         from pycbc.waveform.spa_tmplt import findchirp_chirptime
 
-        # FIXME spins are not taken into account
         f_high = f_SchwarzISCO(mass1 + mass2)
 
         def tof_func(f):
-            return findchirp_chirptime(float(mass1), float(mass2), float(f), pn_2order)
+            return findchirp_chirptime(
+                float(mass1), float(mass2), float(f), pn_2order,
+                s1z=float(spin1), s2z=float(spin2))
     elif approximant.startswith("SEOBNRv"):
         approximant_prefix = approximant[: len("SEOBNRv*")]
         f_high = get_final_freq(approximant_prefix, mass1, mass2, spin1, spin2)

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -51,7 +51,7 @@ def findchirp_chirptime(m1, m2, fLower, porder=-1, s1z=0., s2z=0.):
         Lower frequency cutoff in Hz.
     porder : int, optional
         Twice the post-Newtonian order of the phasing (e.g. 7 for 3.5PN).
-        The default (-1) uses the highest implemented order.
+        The default (-1) lets LAL use the highest implemented order.
     s1z, s2z : float, optional
         Dimensionless spin components aligned with the orbital angular
         momentum. Default to zero (non-spinning).
@@ -61,11 +61,12 @@ def findchirp_chirptime(m1, m2, fLower, porder=-1, s1z=0., s2z=0.):
     m_sec = (m1 + m2) * MTSUN_SI
     eta = m1 * m2 / (m1 + m2) ** 2
 
-    if porder == -1:
-        porder = 7
-
     lal_pars = lal.CreateDict()
-    lalsimulation.SimInspiralWaveformParamsInsertPNPhaseOrder(lal_pars, porder)
+    if porder != -1:
+        # otherwise LAL defaults to its highest implemented order, matching
+        # the behaviour of spa_tmplt with phase_order=-1
+        lalsimulation.SimInspiralWaveformParamsInsertPNPhaseOrder(
+            lal_pars, porder)
     phasing = lalsimulation.SimInspiralTaylorF2AlignedPhasing(
         m1, m2, float(s1z), float(s2z), lal_pars)
 

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -29,62 +29,66 @@ import pycbc.pnutils
 from pycbc.scheme import schemed
 from pycbc.types import FrequencySeries, Array, complex64, float32, zeros
 from pycbc.waveform.utils import ceilpow2
-from pycbc.constants import PI, GAMMA, MTSUN_SI, PC_SI, MRSUN_SI
+from pycbc.constants import PI, MTSUN_SI, PC_SI, MRSUN_SI
 from pycbc.libutils import import_optional
 
 lal = import_optional('lal')
 lalsimulation = import_optional('lalsimulation')
 
-def findchirp_chirptime(m1, m2, fLower, porder):
-    # variables used to compute chirp time
+def findchirp_chirptime(m1, m2, fLower, porder=-1, s1z=0., s2z=0.):
+    """Estimate the chirp time, i.e. the time from ``fLower`` to coalescence,
+    of a TaylorF2 / stationary-phase-approximation waveform.
+
+    The post-Newtonian coefficients are taken directly from LAL's
+    ``SimInspiralTaylorF2AlignedPhasing`` rather than being hardcoded, so
+    aligned-spin contributions to the phasing are included.
+
+    Parameters
+    ----------
+    m1, m2 : float
+        Component masses in solar masses.
+    fLower : float or numpy.ndarray
+        Lower frequency cutoff in Hz.
+    porder : int, optional
+        Twice the post-Newtonian order of the phasing (e.g. 7 for 3.5PN).
+        The default (-1) uses the highest implemented order.
+    s1z, s2z : float, optional
+        Dimensionless spin components aligned with the orbital angular
+        momentum. Default to zero (non-spinning).
+    """
     m1 = float(m1)
     m2 = float(m2)
-    m = m1 + m2
-    eta = m1 * m2 / m / m
-    c0T = c2T = c3T = c4T = c5T = c6T = c6LogT = c7T = 0.
+    m_sec = (m1 + m2) * MTSUN_SI
+    eta = m1 * m2 / (m1 + m2) ** 2
 
-    # All implemented option
     if porder == -1:
         porder = 7
 
-    if porder >= 7:
-        c7T = PI * (14809.0 * eta * eta / 378.0 - 75703.0 * eta / 756.0 - 15419335.0 / 127008.0)
+    lal_pars = lal.CreateDict()
+    lalsimulation.SimInspiralWaveformParamsInsertPNPhaseOrder(lal_pars, porder)
+    phasing = lalsimulation.SimInspiralTaylorF2AlignedPhasing(
+        m1, m2, float(s1z), float(s2z), lal_pars)
 
-    if porder >= 6:
-        c6T = GAMMA * 6848.0 / 105.0 - 10052469856691.0 / 23471078400.0 +\
-            PI * PI * 128.0 / 3.0 + \
-            eta * (3147553127.0 / 3048192.0 - PI * PI * 451.0 / 12.0) -\
-            eta * eta * 15211.0 / 1728.0 + eta * eta * eta * 25565.0 / 1296.0 +\
-            eta * eta * eta * 25565.0 / 1296.0 + numpy.log(4.0) * 6848.0 / 105.0
-        c6LogT = 6848.0 / 105.0
+    # PN expansion parameter v evaluated at the lower frequency cutoff
+    v = (PI * m_sec * fLower) ** (1.0 / 3.0)
+    lnv = numpy.log(v)
 
-    if porder >= 5:
-        c5T = 13.0 * PI * eta / 3.0 - 7729.0 * PI / 252.0
+    pfaN = phasing.v[0]
 
-    if porder >= 4:
-        c4T = 3058673.0 / 508032.0 + eta * (5429.0 / 504.0 + eta * 617.0 / 72.0)
-        c3T = -32.0 * PI / 5.0
-        c2T = 743.0 / 252.0 + eta * 11.0 / 3.0
-        c0T = 5.0 * m * MTSUN_SI / (256.0 * eta)
+    # In the stationary phase approximation the time-frequency relation is
+    # t(f) = (1 / 2 pi) dPsi/df, so a phasing term (phi_k + phi_kl ln v) v^k
+    # contributes to the chirp time tC = t_coalescence - t(fLower) with a
+    # factor (5 - k) / 5 relative to the Newtonian term, plus an extra
+    # -phi_kl / 5 v^k piece from differentiating the logarithm.
+    series = 1.0
+    for k in range(2, 8):
+        phi_k = phasing.v[k] / pfaN
+        phi_kl = phasing.vlogv[k] / pfaN
+        series = series + v ** k * (
+            (5.0 - k) / 5.0 * (phi_k + phi_kl * lnv) - phi_kl / 5.0)
 
-    # This is the PN parameter v evaluated at the lower freq. cutoff
-    xT = pow (PI * m * MTSUN_SI * fLower, 1.0 / 3.0)
-    x2T = xT * xT
-    x3T = xT * x2T
-    x4T = x2T * x2T
-    x5T = x2T * x3T
-    x6T = x3T * x3T
-    x7T = x3T * x4T
-    x8T = x4T * x4T
-
-    # Computes the chirp time as tC = t(v_low);
-    # tC = t(v_low) - t(v_upper) would be more
-    # correct, but the difference is negligible.
-
-    # This formula works for any PN order, because
-    # higher order coeffs will be set to zero.
-    return c0T * (1 + c2T * x2T + c3T * x3T + c4T * x4T + c5T * x5T +
-                  (c6T + c6LogT * numpy.log(xT)) * x6T + c7T * x7T) / x8T
+    tN = 5.0 * m_sec / (256.0 * eta * v ** 8)
+    return tN * series
 
 
 def spa_length_in_time(**kwds):
@@ -97,11 +101,10 @@ def spa_length_in_time(**kwds):
     m2 = kwds['mass2']
     flow = kwds['f_lower']
     porder = int(kwds['phase_order'])
+    s1z = kwds.get('spin1z') or 0.
+    s2z = kwds.get('spin2z') or 0.
 
-    # For now, we call the swig-wrapped function below in
-    # lalinspiral.  Eventually would be nice to replace this
-    # with a function using PN coeffs from lalsimulation.
-    return findchirp_chirptime(m1, m2, flow, porder)
+    return findchirp_chirptime(m1, m2, flow, porder, s1z=s1z, s2z=s2z)
 
 
 def spa_amplitude_factor(**kwds):

--- a/test/test_spatmplt.py
+++ b/test/test_spatmplt.py
@@ -25,10 +25,16 @@
 These are the unittests for the pycbc.waveform module
 """
 import unittest
+import numpy
 from pycbc.types import zeros, complex64
 from pycbc.filter import overlap
 from pycbc.waveform import get_fd_waveform, get_waveform_filter
+from pycbc.waveform.spa_tmplt import findchirp_chirptime
+from pycbc import pnutils
 from utils import parse_args_all_schemes, simple_exit
+
+import lal
+import lalsimulation
 
 _scheme, _context = parse_args_all_schemes("Waveform")
 
@@ -71,8 +77,106 @@ class TestSPAtmplt(unittest.TestCase):
                             print("checked m1: %s m2:: %s s1z: %s s2z: %s] overlap = %s, diff = %s" % (m1, m2, s1, s2, o, diff))
 
 
+class TestChirpTime(unittest.TestCase):
+    """Tests for ``findchirp_chirptime``, which derives its PN coefficients
+    from LAL's TaylorF2 aligned-spin phasing.
+    """
+
+    def test_vs_taylorf2_phase(self):
+        """The chirp time is, by construction, t_coalescence - t(f) with
+        t(f) = (1 / 2 pi) dPsi/df in the stationary phase approximation.
+        Cross-check it against the derivative of the actual LAL TaylorF2
+        frequency-domain phase: the time between two in-band frequencies
+        t(f1) - t(f2) must match the difference of the chirp times.
+        """
+        delta_f = 1.0 / 256
+        f_lower = 15.0
+        f1, f2 = 30.0, 55.0
+        cases = [
+            (1.2, 1.3, 0.0, 0.0),
+            (1.4, 1.4, 0.7, 0.3),
+            (1.4, 1.4, -0.7, -0.3),
+            (2.5, 1.4, 0.4, 0.0),
+            (10.0, 10.0, 0.0, 0.0),
+            (10.0, 1.4, 0.6, 0.0),
+            (20.0, 20.0, 0.5, 0.5),
+            (30.0, 20.0, -0.6, 0.2),
+            (5.0, 5.0, -0.8, -0.8),
+        ]
+        for m1, m2, s1z, s2z in cases:
+            hp, _ = get_fd_waveform(
+                approximant="TaylorF2", mass1=m1, mass2=m2,
+                spin1z=s1z, spin2z=s2z, delta_f=delta_f, f_lower=f_lower,
+                f_final=512.0, phase_order=-1, spin_order=-1)
+            freq = hp.sample_frequencies.numpy()
+            phase = numpy.unwrap(numpy.angle(hp.numpy()))
+
+            def t_of_f(f0, half=1.0):
+                sel = (freq > f0 - half) & (freq < f0 + half)
+                # local cubic fit removes the (strong) phase curvature bias
+                coeffs = numpy.polyfit(freq[sel] - f0, phase[sel], 3)
+                return coeffs[2] / (2 * numpy.pi)
+
+            dt_phase = -(t_of_f(f2) - t_of_f(f1))
+            dt_formula = (findchirp_chirptime(m1, m2, f1, 7, s1z=s1z, s2z=s2z)
+                          - findchirp_chirptime(m1, m2, f2, 7, s1z=s1z, s2z=s2z))
+            self.assertAlmostEqual(dt_formula / dt_phase, 1.0, places=3,
+                                   msg=f"m1={m1} m2={m2} s1z={s1z} s2z={s2z}")
+
+    def test_roughly_matches_reduced_spin(self):
+        """For light-to-moderate mass, moderately spinning systems the
+        aligned-spin chirp time should roughly agree with LAL's
+        reduced-spin TaylorF2 chirp time.
+        """
+        f_lower = 20.0
+        for m1 in [1.2, 1.4, 3.0, 6.0, 10.0]:
+            for m2 in [1.3, 1.4, 5.0, 10.0]:
+                if m1 + m2 > 25.0:
+                    continue
+                for s1z in [-0.7, -0.3, 0.0, 0.3, 0.7]:
+                    for s2z in [-0.7, 0.0, 0.7]:
+                        chi = lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(
+                            m1, m2, s1z, s2z)
+                        red = lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
+                            f_lower, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, 7)
+                        mine = findchirp_chirptime(
+                            m1, m2, f_lower, 7, s1z=s1z, s2z=s2z)
+                        self.assertAlmostEqual(
+                            mine / red, 1.0, delta=0.02,
+                            msg=f"m1={m1} m2={m2} s1z={s1z} s2z={s2z}")
+
+    def test_nonspinning_unchanged(self):
+        """Spin defaults to zero, and the non-spinning result is the plain
+        TaylorF2 chirp time (regression guard against accidental spin leakage).
+        """
+        for m1, m2 in [(1.4, 1.4), (10.0, 1.4), (25.0, 25.0)]:
+            no_spin = findchirp_chirptime(m1, m2, 20.0, 7)
+            explicit_zero = findchirp_chirptime(m1, m2, 20.0, 7, s1z=0.0, s2z=0.0)
+            self.assertEqual(no_spin, explicit_zero)
+            # aligned spin lengthens, anti-aligned shortens the inspiral
+            self.assertGreater(
+                findchirp_chirptime(m1, m2, 20.0, 7, s1z=0.6, s2z=0.6), no_spin)
+            self.assertLess(
+                findchirp_chirptime(m1, m2, 20.0, 7, s1z=-0.6, s2z=-0.6), no_spin)
+
+    def test_get_inspiral_tf_uses_spin(self):
+        """pnutils.get_inspiral_tf passes spins through to the TaylorF2
+        time-frequency track.
+        """
+        kwargs = dict(tc=0.0, mass1=15.0, mass2=1.4, f_low=20.0,
+                      approximant="TaylorF2")
+        t_aligned, f_track = pnutils.get_inspiral_tf(spin1=0.8, spin2=0.0, **kwargs)
+        t_anti, _ = pnutils.get_inspiral_tf(spin1=-0.8, spin2=0.0, **kwargs)
+        t_nospin, _ = pnutils.get_inspiral_tf(spin1=0.0, spin2=0.0, **kwargs)
+        # at the lowest tracked frequency the aligned-spin system has a longer
+        # inspiral, so it starts further before the coalescence time
+        self.assertLess(t_aligned[0], t_nospin[0])
+        self.assertGreater(t_anti[0], t_nospin[0])
+
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestSPAtmplt))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestChirpTime))
 
 if __name__ == '__main__':
     results = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_spatmplt.py
+++ b/test/test_spatmplt.py
@@ -165,7 +165,7 @@ class TestChirpTime(unittest.TestCase):
         """
         kwargs = dict(tc=0.0, mass1=15.0, mass2=1.4, f_low=20.0,
                       approximant="TaylorF2")
-        t_aligned, f_track = pnutils.get_inspiral_tf(spin1=0.8, spin2=0.0, **kwargs)
+        t_aligned, _ = pnutils.get_inspiral_tf(spin1=0.8, spin2=0.0, **kwargs)
         t_anti, _ = pnutils.get_inspiral_tf(spin1=-0.8, spin2=0.0, **kwargs)
         t_nospin, _ = pnutils.get_inspiral_tf(spin1=0.0, spin2=0.0, **kwargs)
         # at the lowest tracked frequency the aligned-spin system has a longer


### PR DESCRIPTION
PyCBC's `findchirp_chirptime` function currently only works for nonspinning waveforms, and hardcodes the PN coefficients. This patch fixes this by un-hardcoding the coefficients (using LAL as we do elsewhere for the SPA waveform) and supporting spins.

In doing so, we also fix a [small] bug where one small term at 3PN order is duplicated. This would never matter at a level we care about but highlights why we shouldn't be duplicating something that's maintained better elsewhere.

While I don't add it here, other things (e.g. tidal terms) could now also be supported reasonably easily.

There also doesn't seem to be a proper `findchirp_chirptime` function anywhere (LAL only has one for reduced spins, that I could find), so having this is useful in general.

## Standard information about the request

This is a: bug fix and functionality change

This change affects: Anything using the SPA waveform, likely mostly searches.

This change changes: scientific output

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

This fixes #4572 and avoids us duplicating information that we use LAL for elsewhere ... The bug present in our implementation shows how easy this is to get wrong and why we shouldn't be doing this.

## Contents

We replace `findchirp_chirptime`'s internals with a call to LAL's phasing (as used in the waveform itself) and then code to compute duration from this. This works for any PN orders now (so for e.g. tidal terms in LAL could also be used here if we hooked the relevant terms up).

## Links to any issues or associated PRs

Fixes #4572

## Testing performed

Comparing non-spinning durations using f_low 20Hz and 3.5PN. The first column is current durations, second after fixing the bug in our old implementation, then after this patch and LAL's ReducedSpin time code. The last 3 should all agree for non-spinning and do.

m1 | m2 | before (as-is, buggy) | before (η³ bug fixed) | after (this patch) | RedSpinChirpTime
-- | -- | -- | -- | -- | --
1.4 | 1.4 | 160.68055 | 160.68051 | 160.68051 | 160.68051
1.4 | 5.0 | 59.14858 | 59.14856 | 59.14856 | 59.14856
10.0 | 1.4 | 35.38996 | 35.38995 | 35.38995 | 35.38995
15.0 | 15.0 | 2.94597 | 2.94589 | 2.94589 | 2.94589
30.0 | 25.0 | 0.97056 | 0.97047 | 0.97047 | 0.97047
50.0 | 50.0 | 0.25716 | 0.25704 | 0.25704 | 0.25704
80.0 | 80.0 | 0.03869 | 0.03855 | 0.03855 | 0.03855

Then the spinning durations. Here we drop the "bug-fixed old implementation" column as we didn't add spins to the old implementation. What we can see is that aligned spin makes longer and anti-aligned makes shorter. We can also compare to LAL's Reduced spin code which should be *close*, but has reduced spins to one number so is a little different.

These tests are added to the test suite.

Finally, in the test suite, we actually generate a SPA waveform and measure the phase evolution from which the chirptime can be directly obtained. This agrees within numerical precision to the new code.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
