### PR TITLE
f_ref bug

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -809,7 +809,7 @@ def _base_get_td_waveform_from_fd(template=None, rwrap=None, **params):
            full_duration >= nparams['t_obs_start']:
             break
 
-    if 'f_ref' not in nparams:
+    if not nparams.get('f_ref'):
         nparams['f_ref'] = params['f_lower']
 
     # factor to ensure the vectors are all large enough. We don't need to


### PR DESCRIPTION
When generating waveforms with `get_td_waveform_from_fd`, `f_ref` is set to `0` in `nparams` if it is not set by the user. Therefore, the `if` statement is never true and cannot set `f_ref` to `f_lower` as intended.